### PR TITLE
feat: Add local testing API and enhance orion/orion-server 

### DIFF
--- a/orion-server/.env
+++ b/orion-server/.env
@@ -1,3 +1,3 @@
-BUILD_LOG_DIR="/tmp/buck2ctl"
+BUILD_LOG_DIR="/tmp/megadir/buck2ctl"
 DATABASE_URL="postgres://postgres:postgres@localhost/orion"
-PORT=8004
+PORT=80

--- a/orion-server/Cargo.toml
+++ b/orion-server/Cargo.toml
@@ -29,3 +29,4 @@ dashmap = { workspace = true }
 utoipa-axum.workspace = true
 utoipa.workspace = true
 utoipa-swagger-ui = { workspace = true, features = ["axum"] }
+chrono = { version = "0.4", features = ["serde"] }

--- a/orion-server/src/api.rs
+++ b/orion-server/src/api.rs
@@ -1,23 +1,26 @@
 use crate::model::builds;
-use axum::Json;
-use axum::body::Bytes;
-use axum::extract::ws::{Message, Utf8Bytes, WebSocket};
-use axum::extract::{ConnectInfo, Path, State, WebSocketUpgrade};
-use axum::http::StatusCode;
-use axum::response::sse::{Event, KeepAlive};
-use axum::response::{IntoResponse, Sse};
-use axum::routing::{any, get};
-use axum_extra::json;
+use axum::{
+    Json, Router,
+    extract::{
+        ConnectInfo, Path, State, WebSocketUpgrade,
+        ws::{Message, Utf8Bytes, WebSocket},
+    },
+    http::StatusCode,
+    response::{IntoResponse, Sse, sse::Event, sse::KeepAlive},
+    routing::{any, get},
+};
 use dashmap::DashMap;
 use futures_util::{SinkExt, Stream, StreamExt, stream};
 use once_cell::sync::Lazy;
 use orion::ws::WSMessage;
-use rand::seq::IndexedRandom;
-use scopeguard::defer;
-use sea_orm::ActiveValue::Set;
-use sea_orm::prelude::DateTimeUtc;
-use sea_orm::sqlx::types::chrono;
-use sea_orm::{ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter as _};
+use rand::Rng;
+use sea_orm::{
+    prelude::DateTimeUtc,
+    {
+        ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait,
+        QueryFilter as _,
+    },
+};
 use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
 use std::io::Write;
@@ -26,15 +29,35 @@ use std::ops::ControlFlow;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::AsyncReadExt;
+use tokio::sync::Mutex;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::UnboundedSender;
 use utoipa::ToSchema;
-use utoipa_axum::{router::OpenApiRouter, routes};
 use uuid::Uuid;
 
+// Global configuration for build log directory
 static BUILD_LOG_DIR: Lazy<String> =
     Lazy::new(|| std::env::var("BUILD_LOG_DIR").expect("BUILD_LOG_DIR must be set"));
 
+/// Creates a log file for a specific task ID
+/// Ensures parent directories exist before creating the file
+fn create_log_file(task_id: &str) -> Result<std::fs::File, std::io::Error> {
+    let log_path = format!("{}/{}", *BUILD_LOG_DIR, task_id);
+    let path = std::path::Path::new(&log_path);
+
+    // Ensure parent directory exists
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    // Create or open the log file in append mode
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+}
+
+/// Request payload for creating a new build task
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct BuildRequest {
     repo: String,
@@ -43,24 +66,45 @@ pub struct BuildRequest {
     mr: Option<String>,
 }
 
+/// Information about an active build task
+#[derive(Clone)]
 pub struct BuildInfo {
-    repo: String,
-    target: String,
-    args: Option<Vec<String>>,
-    start_at: DateTimeUtc,
-    mr: Option<String>,
+    pub repo: String,
+    pub target: String,
+    pub args: Option<Vec<String>>,
+    pub start_at: DateTimeUtc,
+    pub mr: Option<String>,
+    pub _worker_id: String,
+    pub log_file: Arc<Mutex<std::fs::File>>,
 }
 
+/// Status of a worker node
+#[derive(Debug, Clone)]
+pub enum WorkerStatus {
+    Idle,
+    Busy(String), // Contains task ID when busy
+}
+
+/// Information about a connected worker
+#[derive(Debug)]
+pub struct WorkerInfo {
+    pub sender: UnboundedSender<WSMessage>,
+    pub status: WorkerStatus,
+    pub last_heartbeat: DateTimeUtc,
+}
+
+/// Enumeration of possible task statuses
 #[derive(Debug, Serialize, Default, ToSchema)]
 pub enum TaskStatusEnum {
     Building,
-    Interrupted, // exit code is None
+    Interrupted, // Task was interrupted, exit code is None
     Failed,
     Completed,
     #[default]
     NotFound,
 }
 
+/// Response structure for task status queries
 #[derive(Debug, Serialize, Default, ToSchema)]
 pub struct TaskStatus {
     status: TaskStatusEnum,
@@ -70,20 +114,22 @@ pub struct TaskStatus {
     message: Option<String>,
 }
 
+/// Shared application state containing worker connections, database, and active builds
 #[derive(Clone)]
 pub struct AppState {
-    pub clients: Arc<DashMap<String, UnboundedSender<WSMessage>>>,
+    pub workers: Arc<DashMap<String, WorkerInfo>>,
     pub conn: DatabaseConnection,
-    pub building: Arc<DashMap<String, BuildInfo>>,
+    pub active_builds: Arc<DashMap<String, BuildInfo>>,
 }
 
-pub fn routers() -> OpenApiRouter<AppState> {
-    OpenApiRouter::new()
+/// Creates and configures all API routes
+pub fn routers() -> Router<AppState> {
+    Router::new()
         .route("/ws", any(ws_handler))
-        .routes(routes!(task_handler))
-        .routes(routes!(task_status_handler))
+        .route("/task", axum::routing::post(task_handler))
+        .route("/task-status/{id}", get(task_status_handler))
         .route("/task-output/{id}", get(task_output_handler))
-        .routes(routes!(task_query_by_mr))
+        .route("/mr-task/{mr}", get(task_query_by_mr))
 }
 
 #[utoipa::path(
@@ -96,11 +142,14 @@ pub fn routers() -> OpenApiRouter<AppState> {
         (status = 200, description = "Task status", body = TaskStatus)
     )
 )]
-async fn task_status_handler(
+/// Retrieves the current status of a build task by its ID
+/// Returns status information including exit code and current state
+pub async fn task_status_handler(
     Path(id): Path<String>,
     State(state): State<AppState>,
 ) -> impl IntoResponse {
-    let (code, status) = if state.building.contains_key(&id) {
+    let (code, status) = if state.active_builds.contains_key(&id) {
+        // Task is currently active/building
         (
             StatusCode::OK,
             TaskStatus {
@@ -109,12 +158,16 @@ async fn task_status_handler(
             },
         )
     } else {
+        // Check database for completed/historical tasks
         match Uuid::parse_str(&id) {
-            Ok(id) => {
-                let output = builds::Model::get_by_build_id(id, state.conn).await;
+            Ok(id_uuid) => {
+                let output = builds::Model::get_by_build_id(id_uuid, &state.conn).await;
                 match output {
                     Some(model) => {
-                        let status = if model.exit_code.is_none() {
+                        // Determine task status based on database fields
+                        let status = if model.end_at.is_none() {
+                            TaskStatusEnum::Building
+                        } else if model.exit_code.is_none() {
                             TaskStatusEnum::Interrupted
                         } else if model.exit_code.unwrap() == 0 {
                             TaskStatusEnum::Completed
@@ -153,56 +206,57 @@ async fn task_status_handler(
     (code, Json(status))
 }
 
-/// SSE
+/// Streams build output logs in real-time using Server-Sent Events (SSE)
+/// Continuously monitors the log file and streams new content as it becomes available
 async fn task_output_handler(
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> Sse<impl Stream<Item = Result<Event, Infallible>>> // impl IntoResponse
-{
-    let path = format!("{}/{}", *BUILD_LOG_DIR, id);
-    if !std::path::Path::new(&path).exists() {
-        // 2 return types must same, which is hard without `.boxed()`
-        // `Sse<Unfold<Reader<File>, ..., ...>>` != Sse<Once<..., ..., ...>> != Sse<Unfold<bool, ..., ...>>
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let log_path_str = format!("{}/{}", *BUILD_LOG_DIR, id);
+    let log_path = std::path::Path::new(&log_path_str);
+
+    // Return error message if log file doesn't exist
+    if !log_path.exists() {
         return Sse::new(
             stream::once(async { Ok(Event::default().data("Task output file not found")) }).boxed(),
         );
     }
 
-    let file = tokio::fs::File::open(&path).await.unwrap(); // read-only mode
+    let file = tokio::fs::File::open(log_path).await.unwrap();
     let reader = tokio::io::BufReader::new(file);
 
+    // Create a stream that continuously reads from the log file
     let stream = stream::unfold(reader, move |mut reader| {
-        let id_c = id.clone(); // must, or err
-        let building = state.building.clone();
+        let id_c = id.clone();
+        let active_builds = state.active_builds.clone();
         async move {
             let mut buf = String::new();
-            let is_building = building.contains_key(&id_c); // MUST check before reading
+            let is_building = active_builds.contains_key(&id_c);
             let size = reader.read_to_string(&mut buf).await.unwrap();
+
             if size == 0 {
                 if is_building {
-                    // wait for new content
+                    // Wait for more content if build is still active
                     tokio::time::sleep(Duration::from_secs(1)).await;
                     let size = reader.read_to_string(&mut buf).await.unwrap();
                     if size > 0 {
-                        tracing::debug!("Read: {}", buf); // little duplicate code, but more efficient
                         Some((Ok(Event::default().data(buf)), reader))
                     } else {
-                        tracing::debug!("Not Modified, waiting...");
-                        // return control to `axum`, or it can't auto-detect client disconnect & close
+                        // Send keep-alive comment
                         Some((Ok(Event::default().comment("")), reader))
                     }
                 } else {
-                    // build end & no more content
+                    // Build finished and no more content
                     None
                 }
             } else {
-                tracing::debug!("Read: {}", buf);
+                // Send new content
                 Some((Ok(Event::default().data(buf)), reader))
             }
         }
     });
 
-    Sse::new(stream.boxed()).keep_alive(KeepAlive::new()) // empty comment to keep alive
+    Sse::new(stream.boxed()).keep_alive(KeepAlive::new())
 }
 
 #[utoipa::path(
@@ -210,231 +264,333 @@ async fn task_output_handler(
     path = "/task",
     request_body = BuildRequest,
     responses(
-        (status = 200, description = "Task created", body = inline(json::Value))
+        (status = 200, description = "Task created", body = serde_json::Value)
     )
 )]
-async fn task_handler(
+/// Creates a new build task and assigns it to an available worker
+/// Returns task ID and assigned worker information upon successful creation
+pub async fn task_handler(
     State(state): State<AppState>,
     Json(req): Json<BuildRequest>,
-) -> impl IntoResponse {
-    let id = Uuid::now_v7().to_string();
-    state.building.insert(
-        id.clone(),
-        BuildInfo {
-            repo: req.repo.clone(),
-            target: req.target.clone(),
-            args: req.args.clone(),
-            start_at: chrono::Utc::now(),
-            mr: req.mr.clone(),
-        },
-    );
-
-    let client_ids: Vec<_> = state
-        .clients
+) -> (StatusCode, Json<serde_json::Value>) {
+    // Find all idle workers
+    let idle_workers: Vec<String> = state
+        .workers
         .iter()
+        .filter(|entry| matches!(entry.value().status, WorkerStatus::Idle))
         .map(|entry| entry.key().clone())
         .collect();
 
-    if client_ids.is_empty() {
-        return json!({"message": "No clients connected"});
+    // Return error if no workers are available
+    if idle_workers.is_empty() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({"message": "No available workers at the moment"})),
+        );
     }
 
-    let mut rng = rand::rng();
-    let chosen_id = client_ids.choose(&mut rng).unwrap();
+    // Randomly select an idle worker
+    let chosen_index = {
+        let mut rng = rand::rng();
+        rng.random_range(0..idle_workers.len())
+    };
+    let chosen_id = idle_workers[chosen_index].clone();
+    let task_id = Uuid::now_v7();
 
+    // Create log file for the task
+    let log_file = match create_log_file(&task_id.to_string()) {
+        Ok(file) => Arc::new(Mutex::new(file)),
+        Err(e) => {
+            tracing::error!("Failed to create log file for task {}: {}", task_id, e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"message": "Failed to create log file"})),
+            );
+        }
+    };
+
+    // Create build information structure
+    let build_info = BuildInfo {
+        repo: req.repo.clone(),
+        target: req.target.clone(),
+        args: req.args.clone(),
+        start_at: chrono::Utc::now(),
+        mr: req.mr.clone(),
+        _worker_id: chosen_id.clone(),
+        log_file,
+    };
+
+    // Save task to database
+    let model = builds::ActiveModel {
+        build_id: Set(task_id),
+        output_file: Set(format!("{}/{}", *BUILD_LOG_DIR, task_id)),
+        exit_code: Set(None),
+        start_at: Set(build_info.start_at),
+        end_at: Set(None),
+        repo_name: Set(build_info.repo.clone()),
+        target: Set(build_info.target.clone()),
+        arguments: Set(build_info.args.clone().unwrap_or_default().join(" ")),
+        mr: Set(build_info.mr.clone().unwrap_or_default()),
+    };
+    if let Err(e) = model.insert(&state.conn).await {
+        tracing::error!("Failed to insert new build task into DB: {}", e);
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"message": "Failed to create task in database"})),
+        );
+    }
+
+    // Create WebSocket message for the worker
     let msg = WSMessage::Task {
-        id: id.clone(),
+        id: task_id.to_string(),
         repo: req.repo,
         target: req.target,
         args: req.args,
-        mr: req.mr.clone().unwrap_or_default(),
+        mr: req.mr.unwrap_or_default(),
     };
 
-    state.clients.get(chosen_id).unwrap().send(msg).unwrap(); // TODO client maybe disconnected
-
-    json!({"task_id": id, "client_id": chosen_id})
+    // Send task to the selected worker
+    if let Some(mut worker) = state.workers.get_mut(&chosen_id) {
+        if worker.sender.send(msg).is_ok() {
+            worker.status = WorkerStatus::Busy(task_id.to_string());
+            state.active_builds.insert(task_id.to_string(), build_info);
+            tracing::info!("Task {} dispatched to worker {}", task_id, chosen_id);
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({"task_id": task_id.to_string(), "client_id": chosen_id})),
+            )
+        } else {
+            tracing::error!(
+                "Failed to send task to supposedly idle worker {}. It might have just disconnected.",
+                chosen_id
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(
+                    serde_json::json!({"message": "Failed to dispatch task to worker. Please try again."}),
+                ),
+            )
+        }
+    } else {
+        tracing::error!(
+            "Chosen idle worker {} not found in map. This should not happen.",
+            chosen_id
+        );
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"message": "Internal scheduler error."})),
+        )
+    }
 }
+
+/// Handles WebSocket upgrade requests from workers
+/// Establishes bidirectional communication channel with worker nodes
 async fn ws_handler(
     ws: WebSocketUpgrade,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     State(state): State<AppState>,
 ) -> impl IntoResponse {
-    println!("{addr} connected.");
+    tracing::info!("{addr} connected. Waiting for registration...");
     ws.on_upgrade(move |socket| handle_socket(socket, addr, state))
 }
 
-/// Actual websocket statemachine (one will be spawned per connection)
-async fn handle_socket(mut socket: WebSocket, who: SocketAddr, state: AppState) {
-    let client_id = Uuid::now_v7().to_string();
+/// Manages WebSocket connection lifecycle for worker communication
+/// Handles message sending/receiving and connection cleanup
+async fn handle_socket(socket: WebSocket, who: SocketAddr, state: AppState) {
     let (tx, mut rx) = mpsc::unbounded_channel::<WSMessage>();
-    let clients = state.clients.clone();
-    clients.insert(client_id.clone(), tx);
-    defer! {
-        println!("clean Client {who}.");
-        clients.remove(&client_id);
-    }
+    let mut worker_id: Option<String> = None;
 
-    // send a ping (unsupported by some browsers) just to kick things off and get a response
-    if socket
-        .send(Message::Ping(Bytes::from_static(b"Server hello")))
-        .await
-        .is_ok()
-    {
-        println!("Pinged {who}...");
-    } else {
-        println!("Could not send ping {who}!");
-        return; // exit
-    }
-
-    // By splitting socket we can send and receive at the same time. In this example we will send
-    // unsolicited messages to client based on some sort of server's internal event (i.e .timer).
     let (mut sender, mut receiver) = socket.split();
 
-    // Spawn a task that will push several messages to the client (does not matter what client does)
-    let mut send_task = tokio::spawn(async move {
+    // Task for sending messages to the worker
+    let send_task = tokio::spawn(async move {
         while let Some(msg) = rx.recv().await {
-            let msg = serde_json::to_string(&msg).unwrap();
+            let msg_str = serde_json::to_string(&msg).unwrap();
             if sender
-                .send(Message::Text(Utf8Bytes::from(msg)))
+                .send(Message::Text(Utf8Bytes::from(msg_str)))
                 .await
                 .is_err()
             {
-                println!("Error sending message to {who}");
+                tracing::warn!("Failed to send message to {who}, client disconnected.");
                 break;
             }
         }
     });
 
-    // This second task will receive messages from client and print them on server console
-    let mut recv_task = tokio::spawn(async move {
+    let state_clone = state.clone();
+    let tx_clone = tx.clone();
+
+    // Task for receiving messages from the worker
+    let recv_task = tokio::spawn(async move {
+        let mut worker_id_inner: Option<String> = None;
         while let Some(Ok(msg)) = receiver.next().await {
-            if process_message(msg, who, state.clone()).await.is_break() {
+            if process_message(msg, who, &state_clone, &mut worker_id_inner, &tx_clone)
+                .await
+                .is_break()
+            {
                 break;
             }
         }
+        worker_id_inner
     });
 
-    // If any one of the tasks exit, abort the other.
     tokio::select! {
-        rv_a = (&mut send_task) => {
-            match rv_a {
-                Ok(_) => println!("send_task to {who} over"),
-                Err(a) => println!("Error sending messages {a:?}")
+        _ = send_task => { },
+        result = recv_task => {
+            if let Ok(final_worker_id) = result {
+                worker_id = final_worker_id;
             }
-            recv_task.abort();
         },
-        rv_b = (&mut recv_task) => {
-            match rv_b {
-                Ok(_) => println!("recv_task from {who} over"),
-                Err(b) => println!("Error receiving messages {b:?}")
-            }
-            send_task.abort();
-        }
     }
 
-    // returning from the handler closes the websocket connection
-    println!("Websocket context {who} destroyed");
+    // Cleanup worker connection when socket closes
+    if let Some(id) = &worker_id {
+        tracing::info!("Cleaning up for worker: {id} from {who}.");
+        state.workers.remove(id);
+    } else {
+        tracing::info!("Cleaning up unregistered connection from {who}.");
+    }
+
+    tracing::info!("Websocket context {who} destroyed");
 }
 
-async fn process_message(msg: Message, who: SocketAddr, state: AppState) -> ControlFlow<(), ()> {
+/// Processes individual WebSocket messages from workers
+/// Handles registration, heartbeats, build output, and completion messages
+async fn process_message(
+    msg: Message,
+    who: SocketAddr,
+    state: &AppState,
+    worker_id: &mut Option<String>,
+    tx: &UnboundedSender<WSMessage>,
+) -> ControlFlow<(), ()> {
     match msg {
-        Message::Text(t) => match serde_json::from_str::<WSMessage>(t.as_str()) {
-            Ok(msg) => match msg {
-                // todo useless ?
-                WSMessage::TaskAck {
-                    id,
-                    success,
-                    message,
-                } => {
-                    println!(">>> task ack: id:{id}, success:{success}, msg:{message}");
+        Message::Text(t) => {
+            let ws_msg: Result<WSMessage, _> = serde_json::from_str(&t);
+            if let Err(e) = ws_msg {
+                tracing::warn!("Failed to parse message from {who}: {e}");
+                return ControlFlow::Continue(());
+            }
+            let ws_msg = ws_msg.unwrap();
+
+            // Handle worker registration (must be first message)
+            if worker_id.is_none() {
+                if let WSMessage::Register { id } = ws_msg {
+                    tracing::info!("Worker from {who} registered as: {id}");
+                    state.workers.insert(
+                        id.clone(),
+                        WorkerInfo {
+                            sender: tx.clone(),
+                            status: WorkerStatus::Idle,
+                            last_heartbeat: chrono::Utc::now(),
+                        },
+                    );
+                    *worker_id = Some(id);
+                } else {
+                    tracing::error!(
+                        "First message from {who} was not Register. Closing connection."
+                    );
+                    return ControlFlow::Break(());
+                }
+                return ControlFlow::Continue(());
+            }
+
+            // Process messages from registered workers
+            let current_worker_id = worker_id.as_ref().unwrap();
+            match ws_msg {
+                WSMessage::Register { .. } => {
+                    tracing::warn!(
+                        "Worker {current_worker_id} sent Register message again. Ignoring."
+                    );
+                }
+                WSMessage::Heartbeat => {
+                    if let Some(mut worker) = state.workers.get_mut(current_worker_id) {
+                        worker.last_heartbeat = chrono::Utc::now();
+                        tracing::debug!("Received heartbeat from {current_worker_id}");
+                    }
                 }
                 WSMessage::BuildOutput { id, output } => {
-                    println!(">>> build output: id:{id}, output:{output}");
-                    let mut file = std::fs::OpenOptions::new() // TODO optimize: open & close too many times
-                        .append(true)
-                        .create(true)
-                        .open(format!("{}/{}", *BUILD_LOG_DIR, id))
-                        .unwrap();
-                    file.write_all(format!("{output}\n").as_bytes()).unwrap();
+                    // Write build output to the associated log file
+                    if let Some(build_info) = state.active_builds.get(&id) {
+                        let log_file = build_info.log_file.clone();
+                        tokio::spawn(async move {
+                            let mut file = log_file.lock().await;
+                            if let Err(e) = writeln!(file, "{output}") {
+                                tracing::error!(
+                                    "Failed to write to log file for task {}: {}",
+                                    id,
+                                    e
+                                );
+                            } else if let Err(e) = file.flush() {
+                                tracing::error!("Failed to flush log file for task {}: {}", id, e);
+                            }
+                        });
+                    } else {
+                        tracing::warn!("Received output for unknown task: {}", id);
+                    }
                 }
                 WSMessage::BuildComplete {
                     id,
-                    success,
+                    success: _,
                     exit_code,
-                    message,
+                    message: _,
                 } => {
-                    println!(
-                        ">>> got build complete: id:{id}, success:{success}, exit_code:{exit_code:?}, msg:{message}"
+                    // Handle build completion
+                    tracing::info!(
+                        "Build {id} completed by worker {current_worker_id} with exit code: {exit_code:?}"
                     );
-                    let info = state.building.get(&id).expect("Build info not found");
-                    let model = builds::ActiveModel {
-                        build_id: Set(id.parse().unwrap()),
-                        output_file: Set(format!("{}/{}", *BUILD_LOG_DIR, id)),
-                        exit_code: Set(exit_code),
-                        start_at: Set(info.start_at),
-                        end_at: Set(chrono::Utc::now()),
-                        repo_name: Set(info.repo.clone()),
-                        target: Set(info.target.clone()),
-                        arguments: Set(info.args.clone().unwrap_or_default().join(" ")),
-                        mr: Set(info.mr.clone().unwrap_or_default()),
-                    };
-                    drop(info); // !!release ref or deadlock when insert
-                    model.insert(&state.conn).await.unwrap();
-                    state.building.remove(&id); // task over
+
+                    // Remove from active builds and update database
+                    state.active_builds.remove(&id);
+                    let _ = builds::Entity::update_many()
+                        .set(builds::ActiveModel {
+                            exit_code: Set(exit_code),
+                            end_at: Set(Some(chrono::Utc::now())),
+                            ..Default::default()
+                        })
+                        .filter(builds::Column::BuildId.eq(id.parse::<uuid::Uuid>().unwrap()))
+                        .exec(&state.conn)
+                        .await;
+
+                    // Mark worker as idle again
+                    if let Some(mut worker) = state.workers.get_mut(current_worker_id) {
+                        worker.status = WorkerStatus::Idle;
+                    }
                 }
-                _ => unreachable!(),
-            },
-            Err(e) => {
-                println!("Error parsing message: {e}");
+                _ => {}
             }
-        },
-        Message::Binary(d) => {
-            println!(">>> {} sent {} bytes: {:?}", who, d.len(), d);
         }
-        Message::Close(c) => {
-            if let Some(cf) = c {
-                println!(
-                    ">>> {} sent close with code {} and reason `{}`",
-                    who, cf.code, cf.reason
-                );
-            } else {
-                println!(">>> {who} somehow sent close message without CloseFrame");
-            }
+        Message::Close(_) => {
+            tracing::info!("Client {who} sent close message.");
             return ControlFlow::Break(());
         }
-        Message::Pong(v) => {
-            println!(">>> {who} sent pong with {v:?}");
-        }
-        // You should never need to manually handle Message::Ping, as axum's websocket library
-        // will do so for you automagically by replying with Pong and copying the v according to
-        // spec. But if you need the contents of the pings you can see them here.
-        Message::Ping(v) => {
-            println!(">>> {who} sent ping with {v:?}");
-        }
+        _ => {}
     }
     ControlFlow::Continue(())
 }
 
+/// Data transfer object for build information in API responses
 #[derive(Debug, Serialize, ToSchema)]
 pub struct BuildDTO {
     pub build_id: String,
     pub output_file: String,
     pub exit_code: Option<i32>,
     pub start_at: String,
-    pub end_at: String,
+    pub end_at: Option<String>,
     pub repo_name: String,
     pub target: String,
     pub arguments: String,
     pub mr: String,
 }
+
 impl BuildDTO {
+    /// Converts a database model to a DTO for API responses
     pub fn from_model(model: builds::Model) -> Self {
         Self {
             build_id: model.build_id.to_string(),
             output_file: model.output_file,
             exit_code: model.exit_code,
             start_at: model.start_at.to_rfc3339(),
-            end_at: model.end_at.to_rfc3339(),
+            end_at: model.end_at.map(|dt| dt.to_rfc3339()),
             repo_name: model.repo_name,
             target: model.target,
             arguments: model.arguments,
@@ -442,11 +598,7 @@ impl BuildDTO {
         }
     }
 }
-/// Query builds by merge request (MR) number
-/// This is a new endpoint to query builds by MR number.
-/// It returns a list of builds associated with the given MR number.
-/// If no builds are found, it returns an empty list.
-/// If an error occurs during the query, it returns an empty list with a 500 status code.
+
 #[utoipa::path(
     get,
     path = "/mr-task/{mr}",
@@ -455,11 +607,13 @@ impl BuildDTO {
     ),
     responses(
         (status = 200, description = "Builds for MR", body = [BuildDTO]),
-        (status = 404, description = "No builds found for the given MR", body = inline(json::Value)),
-        (status = 500, description = "Internal server error", body = inline(json::Value))
+        (status = 404, description = "No builds found for the given MR", body = serde_json::Value),
+        (status = 500, description = "Internal server error", body = serde_json::Value)
     )
 )]
-async fn task_query_by_mr(
+/// Retrieves all build tasks associated with a specific merge request
+/// Returns a list of builds filtered by MR number
+pub async fn task_query_by_mr(
     State(state): State<AppState>,
     Path(mr): Path<String>,
 ) -> Result<Json<Vec<BuildDTO>>, (StatusCode, Json<serde_json::Value>)> {
@@ -486,8 +640,10 @@ async fn task_query_by_mr(
         }
     }
 }
+
 #[cfg(test)]
 mod tests {
+    /// Test random number generation for worker selection
     #[test]
     fn test_rng() {
         use rand::seq::IndexedRandom;

--- a/orion-server/src/main.rs
+++ b/orion-server/src/main.rs
@@ -2,16 +2,23 @@ mod api;
 mod model;
 mod server;
 
+/// Orion Build Server
+/// A distributed build system that manages build tasks and worker nodes
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt() // default is INFO
+    // Initialize logging with DEBUG level
+    tracing_subscriber::fmt()
         .with_max_level(tracing::Level::DEBUG)
         .init();
 
-    dotenvy::dotenv().ok(); // .env file is optional
+    // Load environment variables from .env file (optional)
+    dotenvy::dotenv().ok();
+
+    // Get server port from environment or use default
     let port: u16 = std::env::var("PORT")
         .unwrap_or_else(|_| "8004".to_string())
         .parse()
         .expect("PORT must be a number");
+
     server::start_server(port).await;
 }

--- a/orion-server/src/model/builds.rs
+++ b/orion-server/src/model/builds.rs
@@ -1,18 +1,23 @@
 use sea_orm::entity::prelude::*;
 use serde::Serialize;
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize)]
+/// Database model for build tasks
+/// Stores information about build jobs including their status, timing, and metadata
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Default)]
 #[sea_orm(table_name = "builds")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub build_id: Uuid,
     pub output_file: String,
-    pub exit_code: Option<i32>, // On Unix, return `None` if the process was terminated by a signal.
+    /// Exit code of the build process. None if process was terminated by signal on Unix
+    pub exit_code: Option<i32>,
     pub start_at: DateTimeUtc,
-    pub end_at: DateTimeUtc,
+    pub end_at: Option<DateTimeUtc>,
     pub repo_name: String,
-    pub target: String, // build target, e.g. "//:main"
+    /// Build target specification (e.g., "//:main")
+    pub target: String,
     pub arguments: String,
+    /// Merge request identifier
     pub mr: String,
 }
 
@@ -22,10 +27,11 @@ pub enum Relation {}
 impl ActiveModelBehavior for ActiveModel {}
 
 impl Model {
-    pub async fn get_by_build_id(build_id: Uuid, conn: DatabaseConnection) -> Option<Model> {
+    /// Retrieves a build record by its UUID from the database
+    pub async fn get_by_build_id(build_id: Uuid, conn: &DatabaseConnection) -> Option<Model> {
         Entity::find()
             .filter(Column::BuildId.eq(build_id))
-            .one(&conn)
+            .one(conn)
             .await
             .expect("Failed to get by `build_id`")
     }

--- a/orion/.env
+++ b/orion/.env
@@ -1,4 +1,4 @@
 BUCK_PROJECT_ROOT="/tmp/megadir/mount"
-SERVER_WS="ws://orion.gitmega.com/ws"
+SERVER_WS="ws://127.0.0.1/ws"
 SELECT_TASK_COUNT="30"
 INITIAL_POLL_INTERVAL_SECS="2"

--- a/orion/src/buck_controller.rs
+++ b/orion/src/buck_controller.rs
@@ -1,7 +1,8 @@
 use crate::ws::WSMessage;
 use once_cell::sync::Lazy;
 use serde_json::{json, Value};
-use std::io;
+// Import complete Error trait for better error handling
+use std::error::Error;
 use std::process::{ExitStatus, Stdio};
 use tokio::io::AsyncBufReadExt;
 use tokio::process::Command;
@@ -11,20 +12,21 @@ use tokio::time::{sleep, Duration};
 static PROJECT_ROOT: Lazy<String> =
     Lazy::new(|| std::env::var("BUCK_PROJECT_ROOT").expect("BUCK_PROJECT_ROOT must be set"));
 
-/// Sends a filesystem mount request to the specified API endpoint and waits for completion
-/// Parameters:
-/// - repo: Repository path to mount
-/// - mr: Merge request number
-///   Returns: Result containing success status on completion, or an error on failure
-pub async fn mount_fs(repo: &str, mr: &str) -> Result<bool, Box<dyn std::error::Error>> {
-    // Create HTTP client
+/// Mounts filesystem via remote API for repository access.
+///
+/// Initiates mount request and polls for completion with exponential backoff.
+/// Required for accessing repository files during build process.
+///
+/// # Arguments
+/// * `repo` - Repository path to mount
+/// * `mr` - Merge request identifier
+///
+/// # Returns
+/// * `Ok(true)` - Mount operation completed successfully
+/// * `Err(_)` - Mount request failed or timed out
+pub async fn mount_fs(repo: &str, mr: &str) -> Result<bool, Box<dyn Error + Send + Sync>> {
     let client = reqwest::Client::new();
-
-    // Step 1: Send mount request to get request_id
-    let mount_payload = json!({
-        "path": repo,
-        "mr": mr,
-    });
+    let mount_payload = json!({ "path": repo, "mr": mr });
 
     let mount_res = client
         .post("http://localhost:2725/api/fs/mount")
@@ -33,53 +35,67 @@ pub async fn mount_fs(repo: &str, mr: &str) -> Result<bool, Box<dyn std::error::
         .send()
         .await?;
 
-    println!("Mount request status: {}", mount_res.status());
-
     let mount_body: Value = mount_res.json().await?;
-    println!("Mount response: {mount_body}");
 
-    // Extract request_id from response
+    if mount_body.get("status").and_then(|v| v.as_str()) != Some("Success") {
+        let err_msg = mount_body
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Mount request failed");
+        return Err(err_msg.into());
+    }
+
     let request_id = mount_body
         .get("request_id")
         .and_then(|v| v.as_str())
         .ok_or("Missing request_id in mount response")?
         .to_string();
 
-    // Check if mount request was successful
-    if mount_body.get("status").and_then(|v| v.as_str()) != Some("Success") {
-        return Err("Mount request failed".into());
-    }
+    tracing::debug!("Mount request initiated with request_id: {}", request_id);
 
-    println!("Mount request initiated with request_id: {request_id}");
+    let max_attempts: u64 = std::env::var("SELECT_TASK_COUNT")
+        .unwrap_or_else(|_| "30".to_string())
+        .parse()
+        .unwrap_or(30);
 
-    // Step 2: Poll for completion
-    let max_attempts = std::env::var("SELECT_TASK_COUNT").unwrap_or("30".into());
-    let max_attempts: u64 = max_attempts.parse().unwrap_or(30);
-    let initial_poll_interval_secs =
-        std::env::var("INITIAL_POLL_INTERVAL_SECS").unwrap_or("10".into());
+    let initial_poll_interval_secs: u64 = std::env::var("INITIAL_POLL_INTERVAL_SECS")
+        .unwrap_or_else(|_| "10".to_string())
+        .parse()
+        .unwrap_or(10);
+
     let max_poll_interval_secs = 120; // Maximum backoff interval: 2 minutes
-    let mut poll_interval = initial_poll_interval_secs.parse::<u64>().unwrap_or(10);
-    for _attempt in 1..=max_attempts {
-        // Wait before checking status
+
+    let mut poll_interval = initial_poll_interval_secs;
+
+    for attempt in 1..=max_attempts {
         sleep(Duration::from_secs(poll_interval)).await;
-        // Exponential backoff: double interval, up to max_poll_interval_secs
         poll_interval = std::cmp::min(poll_interval * 2, max_poll_interval_secs);
 
         let select_url = format!("http://localhost:2725/api/fs/select/{request_id}");
         let select_res = client.get(&select_url).send().await?;
-
         let select_body: Value = select_res.json().await?;
-        println!("Select response: {select_body}");
 
-        // Check overall status
+        tracing::debug!(
+            "Polling mount status (attempt {}/{}): {:?}",
+            attempt,
+            max_attempts,
+            select_body
+        );
+
         if select_body.get("status").and_then(|v| v.as_str()) != Some("Success") {
-            return Err("Select request failed".into());
+            let err_msg = select_body
+                .get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Select request failed");
+            return Err(err_msg.into());
         }
 
-        // Check task status
         match select_body.get("task_status").and_then(|v| v.as_str()) {
             Some("finished") => {
-                println!("Mount task completed successfully");
+                tracing::info!(
+                    "Mount task completed successfully for request_id: {}",
+                    request_id
+                );
                 return Ok(true);
             }
             Some("error") => {
@@ -89,22 +105,31 @@ pub async fn mount_fs(repo: &str, mr: &str) -> Result<bool, Box<dyn std::error::
                     .unwrap_or("Unknown error");
                 return Err(format!("Mount task failed: {message}").into());
             }
-            Some("fetching") => {
-                println!("Mount task still in progress (fetching)...");
-                continue;
-            }
-            Some(other_status) => {
-                println!("Mount task status: {other_status}");
-                continue;
-            }
-            None => {
-                return Err("Missing task_status in select response".into());
-            }
+            _ => continue,
         }
     }
+
     Err("Mount operation timed out".into())
 }
 
+/// Executes buck build with filesystem mounting and output streaming.
+///
+/// Process flow:
+/// 1. Mount repository filesystem via remote API
+/// 2. Execute buck build command with specified target and arguments  
+/// 3. Stream build output in real-time via WebSocket
+/// 4. Return final build status
+///
+/// # Arguments
+/// * `id` - Build task identifier for logging and tracking
+/// * `repo` - Repository path for filesystem mounting
+/// * `target` - Buck build target specification  
+/// * `args` - Additional command-line arguments for buck
+/// * `mr` - Merge request context identifier
+/// * `sender` - WebSocket channel for streaming build output
+///
+/// # Returns
+/// Process exit status indicating build success or failure
 pub async fn build(
     id: String,
     repo: String,
@@ -112,71 +137,70 @@ pub async fn build(
     args: Vec<String>,
     mr: String,
     sender: UnboundedSender<WSMessage>,
-) -> io::Result<ExitStatus> {
-    tracing::info!("Building {} in repo {} with target {}", id, repo, target);
-    // Prepare the command to run
-    // Note: `args` is a list of additional arguments to pass to the `buck
+) -> Result<ExitStatus, Box<dyn Error + Send + Sync>> {
+    tracing::info!(
+        "[Task {}] Building target '{}' in repo '{}'",
+        id,
+        target,
+        repo
+    );
 
-    // Mount filesystem before building
-    match mount_fs(&repo, &mr).await {
-        Ok(true) => {
-            tracing::info!("Filesystem mounted successfully for repo: {}", repo);
-        }
-        Ok(false) => {
-            tracing::error!("Filesystem mount failed for repo: {}", repo);
-            return Err(io::Error::other("Filesystem mount failed"));
-        }
-        Err(e) => {
-            tracing::error!("Error mounting filesystem for repo {}: {}", repo, e);
-            return Err(io::Error::other(format!("Filesystem mount error: {e}")));
-        }
-    }
+    mount_fs(&repo, &mr).await?;
+    tracing::info!("[Task {}] Filesystem mounted successfully.", id);
 
     let mut cmd = Command::new("buck2");
     let cmd = cmd
         .arg("build")
         .args(args)
-        .arg(target)
+        .arg(&target)
         .current_dir(format!("{}/{}", *PROJECT_ROOT, repo))
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    // actually, some info (like: "BUILD SUCCESSFUL") is printed to stderr
 
-    tracing::debug!("cmd:{:?}", cmd);
+    tracing::debug!("[Task {}] Executing command: {:?}", id, cmd);
 
     let mut child = cmd.spawn()?;
     let stdout = child.stdout.take().unwrap();
     let stderr = child.stderr.take().unwrap();
     let mut stdout_reader = tokio::io::BufReader::new(stdout).lines();
     let mut stderr_reader = tokio::io::BufReader::new(stderr).lines();
+
     loop {
         tokio::select! {
             result = stdout_reader.next_line() => {
                 match result {
                     Ok(Some(line)) => {
-                        sender.send(WSMessage::BuildOutput {
-                            id: id.clone(),
-                            output: line.clone(),
-                        }).unwrap();
+                        if sender.send(WSMessage::BuildOutput { id: id.clone(), output: line }).is_err() {
+                            child.kill().await?;
+                            return Err("WebSocket connection lost during build.".into());
+                        }
                     },
-                    Err(_) => break,
-                    _ => (),
+                    Ok(None) => break,
+                    Err(e) => {
+                        tracing::error!("[Task {}] Error reading stdout: {}", id, e);
+                        break;
+                    }
                 }
-            }
+            },
             result = stderr_reader.next_line() => {
                 match result {
                     Ok(Some(line)) => {
-                        sender.send(WSMessage::BuildOutput {
-                            id: id.clone(),
-                            output: line.clone(),
-                        }).unwrap();
+                        if sender.send(WSMessage::BuildOutput { id: id.clone(), output: line }).is_err() {
+                            child.kill().await?;
+                            return Err("WebSocket connection lost during build.".into());
+                        }
                     },
-                    Err(_) => break,
-                    _ => (),
+                    Ok(None) => break,
+                    Err(e) => {
+                        tracing::error!("[Task {}] Error reading stderr: {}", id, e);
+                        break;
+                    },
                 }
-            }
-            result = child.wait() => {
-                return result;
+            },
+            status = child.wait() => {
+                let exit_status = status?;
+                tracing::info!("[Task {}] Buck2 process finished with status: {}", id, exit_status);
+                return Ok(exit_status);
             }
         }
     }


### PR DESCRIPTION
Part of https://github.com/web3infra-foundation/mega/issues/1274
feat: Add local testing API and enhance orion/orion-server with heartbeat and task scheduling
  1.Added a new API in mono to enable local testing without login requirement
  2.Implemented heartbeat mechanism in orion-server and orion for persistent connection and reconnection
  3.Added task scheduling and status checking features in orion-server and orion