### PR TITLE
refactor(db): refactors the entire db access layer to support transaction

### DIFF
--- a/libra/src/internal/branch.rs
+++ b/libra/src/internal/branch.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use sea_orm::ActiveModelTrait;
+use sea_orm::{ActiveModelTrait, ConnectionTrait};
 use sea_orm::ActiveValue::Set;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 
@@ -16,8 +16,11 @@ pub struct Branch {
     pub remote: Option<String>,
 }
 
-async fn query_reference(branch_name: &str, remote: Option<&str>) -> Option<reference::Model> {
-    let db_conn = get_db_conn_instance().await;
+//  `_with_conn` version of the helper function
+async fn query_reference_with_conn<C>(db: &C, branch_name: &str, remote: Option<&str>) -> Option<reference::Model>
+where
+    C: ConnectionTrait,
+{
     reference::Entity::find()
         .filter(reference::Column::Name.eq(branch_name))
         .filter(reference::Column::Kind.eq(reference::ConfigKind::Branch))
@@ -25,23 +28,46 @@ async fn query_reference(branch_name: &str, remote: Option<&str>) -> Option<refe
             Some(remote) => reference::Column::Remote.eq(remote),
             None => reference::Column::Remote.is_null(),
         })
-        .one(db_conn)
+        .one(db)
         .await
         .unwrap()
 }
 
+/*
+ * =================================================================================
+ * NOTE: Transaction Safety Pattern (`_with_conn`)
+ * =================================================================================
+ *
+ * This module follows the `_with_conn` pattern for transaction safety.
+ *
+ * - Public functions (e.g., `find_branch`, `update_branch`) acquire a new database
+ *   connection from the pool and are suitable for single, non-transactional operations.
+ *
+ * - `*_with_conn` variants (e.g., `find_branch_with_conn`, `update_branch_with_conn`)
+ *   accept an existing connection or transaction handle (`&C where C: ConnectionTrait`).
+ *
+ * **WARNING**: To use these functions within a database transaction (e.g., inside
+ * a `db.transaction(|txn| { ... })` block), you MUST call the `*_with_conn`
+ * variant, passing the transaction handle `txn`. Calling a public version from
+ * inside a transaction will try to acquire a second connection from the pool,
+ * leading to a deadlock.
+ *
+ * Correct Usage (in a transaction): `Branch::update_branch_with_conn(txn, ...).await;`
+ * Incorrect Usage (in a transaction): `Branch::update_branch(...).await;` // DEADLOCK!
+ */
 impl Branch {
-    /// list all remote branches
-    pub async fn list_branches(remote: Option<&str>) -> Vec<Self> {
-        let db_conn = get_db_conn_instance().await;
-
+    //  `_with_conn` version for `list_branches`
+    pub async fn list_branches_with_conn<C>(db: &C, remote: Option<&str>) -> Vec<Self>
+    where
+        C: ConnectionTrait,
+    {
         let branches = reference::Entity::find()
             .filter(reference::Column::Kind.eq(reference::ConfigKind::Branch))
             .filter(match remote {
                 Some(remote) => reference::Column::Remote.eq(remote),
                 None => reference::Column::Remote.is_null(),
             })
-            .all(db_conn)
+            .all(db)
             .await
             .unwrap();
 
@@ -55,15 +81,33 @@ impl Branch {
             .collect()
     }
 
-    /// is the branch exists
-    pub async fn exists(branch_name: &str) -> bool {
-        let branch = Self::find_branch(branch_name, None).await;
+    /// list all remote branches
+    pub async fn list_branches(remote: Option<&str>) -> Vec<Self> {
+        let db_conn = get_db_conn_instance().await;
+        Self::list_branches_with_conn(db_conn, remote).await
+    }
+
+    //  `_with_conn` version for `exists`
+    pub async fn exists_with_conn<C>(db: &C, branch_name: &str) -> bool
+    where
+        C: ConnectionTrait,
+    {
+        let branch = Self::find_branch_with_conn(db, branch_name, None).await;
         branch.is_some()
     }
 
-    /// get the branch by name
-    pub async fn find_branch(branch_name: &str, remote: Option<&str>) -> Option<Self> {
-        let branch = query_reference(branch_name, remote).await;
+    /// is the branch exists
+    pub async fn exists(branch_name: &str) -> bool {
+        let db_conn = get_db_conn_instance().await;
+        Self::exists_with_conn(db_conn, branch_name).await
+    }
+
+    //  `_with_conn` version for `find_branch`
+    pub async fn find_branch_with_conn<C>(db: &C, branch_name: &str, remote: Option<&str>) -> Option<Self>
+    where
+        C: ConnectionTrait,
+    {
+        let branch = query_reference_with_conn(db, branch_name, remote).await;
         match branch {
             Some(branch) => Some(Branch {
                 name: branch.name.as_ref().unwrap().clone(),
@@ -74,25 +118,33 @@ impl Branch {
         }
     }
 
-    /// search branch with full name, return vec of branches
-    /// e.g. `origin/sub/master/feature` may means `origin/sub/master` + `feature` or `origin/sub` + `master/feature`
-    /// so we need to search all possible branches
-    pub async fn search_branch(branch_name: &str) -> Vec<Self> {
-        let mut branch_name = branch_name.to_string();
+    /// get the branch by name
+    pub async fn find_branch(branch_name: &str, remote: Option<&str>) -> Option<Self> {
+        let db_conn = get_db_conn_instance().await;
+        Self::find_branch_with_conn(db_conn, branch_name, remote).await
+    }
+
+    //  `_with_conn` version for `search_branch`
+    pub async fn search_branch_with_conn<C>(db: &C, branch_name: &str) -> Vec<Self>
+    where
+        C: ConnectionTrait,
+    {
+        let mut branch_name_str = branch_name.to_string();
         let mut remote = String::new();
 
         let mut branches = vec![];
-        if let Some(branch) = Self::find_branch(&branch_name, None).await {
+        if let Some(branch) = Self::find_branch_with_conn(db, &branch_name_str, None).await {
             branches.push(branch)
         }
 
-        while let Some(index) = branch_name.find('/') {
+        while let Some(index) = branch_name_str.find('/') {
             if !remote.is_empty() {
                 remote += "/";
             }
-            remote += branch_name.get(..index).unwrap();
-            branch_name = branch_name.get(index + 1..).unwrap().to_string();
-            let branch = Self::find_branch(&branch_name, Some(&remote)).await;
+            remote += branch_name_str.get(..index).unwrap();
+            branch_name_str = branch_name_str.get(index + 1..).unwrap().to_string();
+            // Important: Call the `_with_conn` variant inside the loop
+            let branch = Self::find_branch_with_conn(db, &branch_name_str, Some(&remote)).await;
             if let Some(branch) = branch {
                 branches.push(branch);
             }
@@ -100,16 +152,26 @@ impl Branch {
         branches
     }
 
-    pub async fn update_branch(branch_name: &str, commit_hash: &str, remote: Option<&str>) {
+    /// search branch with full name, return vec of branches
+    /// e.g. `origin/sub/master/feature` may means `origin/sub/master` + `feature` or `origin/sub` + `master/feature`
+    /// so we need to search all possible branches
+    pub async fn search_branch(branch_name: &str) -> Vec<Self> {
         let db_conn = get_db_conn_instance().await;
-        // check if branch exists
-        let branch = query_reference(branch_name, remote).await;
+        Self::search_branch_with_conn(db_conn, branch_name).await
+    }
+
+    //  `_with_conn` version for `update_branch`
+    pub async fn update_branch_with_conn<C>(db: &C, branch_name: &str, commit_hash: &str, remote: Option<&str>)
+    where
+        C: ConnectionTrait,
+    {
+        let branch = query_reference_with_conn(db, branch_name, remote).await;
 
         match branch {
             Some(branch) => {
                 let mut branch: reference::ActiveModel = branch.into();
                 branch.commit = Set(Some(commit_hash.to_owned()));
-                branch.update(db_conn).await.unwrap();
+                branch.update(db).await.unwrap();
             }
             None => {
                 reference::ActiveModel {
@@ -119,18 +181,31 @@ impl Branch {
                     remote: Set(remote.map(|s| s.to_owned())),
                     ..Default::default()
                 }
-                .insert(db_conn)
-                .await
-                .unwrap();
+                    .insert(db)
+                    .await
+                    .unwrap();
             }
         }
     }
 
+    pub async fn update_branch(branch_name: &str, commit_hash: &str, remote: Option<&str>) {
+        let db_conn = get_db_conn_instance().await;
+        Self::update_branch_with_conn(db_conn, branch_name, commit_hash, remote).await
+    }
+
+    // `_with_conn` version for `delete_branch`
+    pub async fn delete_branch_with_conn<C>(db: &C, branch_name: &str, remote: Option<&str>)
+    where
+        C: ConnectionTrait,
+    {
+        let branch: reference::ActiveModel =
+            query_reference_with_conn(db, branch_name, remote).await.unwrap().into();
+        branch.delete(db).await.unwrap();
+    }
+
     pub async fn delete_branch(branch_name: &str, remote: Option<&str>) {
         let db_conn = get_db_conn_instance().await;
-        let branch: reference::ActiveModel =
-            query_reference(branch_name, remote).await.unwrap().into();
-        branch.delete(db_conn).await.unwrap();
+        Self::delete_branch_with_conn(db_conn, branch_name, remote).await
     }
 }
 

--- a/libra/src/internal/config.rs
+++ b/libra/src/internal/config.rs
@@ -1,15 +1,15 @@
 use std::collections::HashSet;
 use std::mem::swap;
 
+use sea_orm::entity::ActiveModelTrait;
 use sea_orm::ActiveValue::Set;
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, ModelTrait, QueryFilter};
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, EntityTrait, ModelTrait, QueryFilter,
+};
 
 use crate::internal::db::get_db_conn_instance;
 use crate::internal::head::Head;
-use crate::internal::model::config;
-use crate::internal::model::config::Model;
-
-use super::model::config::ActiveModel;
+use crate::internal::model::config::{self, ActiveModel, Model};
 
 pub struct Config;
 
@@ -24,10 +24,37 @@ pub struct BranchConfig {
     pub remote: String,
 }
 
+/*
+ * =================================================================================
+ * NOTE: Transaction Safety Pattern (`_with_conn`)
+ * =================================================================================
+ *
+ * This module follows the `_with_conn` pattern for transaction safety.
+ *
+ * - Public functions (e.g., `get`, `update`) acquire a new database
+ *   connection from the pool and are suitable for single, non-transactional operations.
+ *
+ * - `*_with_conn` variants (e.g., `get_with_conn`, `update_with_conn`)
+ *   accept an existing connection or transaction handle (`&C where C: ConnectionTrait`).
+ *
+ * **WARNING**: To use these functions within a database transaction (e.g., inside
+ * a `db.transaction(|txn| { ... })` block), you MUST call the `*_with_conn`
+ * variant, passing the transaction handle `txn`. Calling a public version from
+ * inside a transaction will try to acquire a second connection from the pool,
+ * leading to a deadlock.
+ *
+ * Correct Usage (in a transaction): `Config::update_with_conn(txn, ...).await;`
+ * Incorrect Usage (in a transaction): `Config::update(...).await;` // DEADLOCK!
+ */
 impl Config {
-    // todo accept a db connect or a transaction from outside
-    pub async fn insert(configuration: &str, name: Option<&str>, key: &str, value: &str) {
-        let db = get_db_conn_instance().await;
+    // _with_conn version for insert
+    pub async fn insert_with_conn<C: ConnectionTrait>(
+        db: &C,
+        configuration: &str,
+        name: Option<&str>,
+        key: &str,
+        value: &str,
+    ) {
         let config = ActiveModel {
             configuration: Set(configuration.to_owned()),
             name: Set(name.map(|s| s.to_owned())),
@@ -38,9 +65,14 @@ impl Config {
         config.save(db).await.unwrap();
     }
 
-    // Update one configuration entry in database using given configuration, name, key and value
-    pub async fn update(configuration: &str, name: Option<&str>, key: &str, value: &str) -> Model {
-        let db = get_db_conn_instance().await;
+    // _with_conn version for update
+    pub async fn update_with_conn<C: ConnectionTrait>(
+        db: &C,
+        configuration: &str,
+        name: Option<&str>,
+        key: &str,
+        value: &str,
+    ) -> Model {
         let mut config: ActiveModel = config::Entity::find()
             .filter(config::Column::Configuration.eq(configuration))
             .filter(match name {
@@ -57,8 +89,13 @@ impl Config {
         config.update(db).await.unwrap()
     }
 
-    async fn query(configuration: &str, name: Option<&str>, key: &str) -> Vec<Model> {
-        let db = get_db_conn_instance().await;
+    // _with_conn version for query
+    async fn query_with_conn<C: ConnectionTrait>(
+        db: &C,
+        configuration: &str,
+        name: Option<&str>,
+        key: &str,
+    ) -> Vec<Model> {
         config::Entity::find()
             .filter(config::Column::Configuration.eq(configuration))
             .filter(match name {
@@ -71,24 +108,28 @@ impl Config {
             .unwrap()
     }
 
-    /// Get one configuration value
-    pub async fn get(configuration: &str, name: Option<&str>, key: &str) -> Option<String> {
-        let values = Self::query(configuration, name, key).await;
+    // _with_conn version for get
+    pub async fn get_with_conn<C: ConnectionTrait>(
+        db: &C,
+        configuration: &str,
+        name: Option<&str>,
+        key: &str,
+    ) -> Option<String> {
+        let values = Self::query_with_conn(db, configuration, name, key).await;
         values.first().map(|c| c.value.to_owned())
     }
 
-    /// Get remote repo name by branch name
-    /// - You may need to `[branch::set-upstream]` if return `None`
-    pub async fn get_remote(branch: &str) -> Option<String> {
-        // e.g. [branch "master"].remote = origin
-        Config::get("branch", Some(branch), "remote").await
+    // _with_conn version for get_remote
+    pub async fn get_remote_with_conn<C: ConnectionTrait>(db: &C, branch: &str) -> Option<String> {
+        Config::get_with_conn(db, "branch", Some(branch), "remote").await
     }
 
-    /// Get remote repo name of current branch
-    /// - `Error` if `HEAD` is detached
-    pub async fn get_current_remote() -> Result<Option<String>, ()> {
-        match Head::current().await {
-            Head::Branch(name) => Ok(Config::get_remote(&name).await),
+    // _with_conn version for get_current_remote
+    pub async fn get_current_remote_with_conn<C: ConnectionTrait>(
+        db: &C,
+    ) -> Result<Option<String>, ()> {
+        match Head::current_with_conn(db).await {
+            Head::Branch(name) => Ok(Config::get_remote_with_conn(db, &name).await),
             Head::Detached(_) => {
                 eprintln!("fatal: HEAD is detached, cannot get remote");
                 Err(())
@@ -96,34 +137,38 @@ impl Config {
         }
     }
 
-    pub async fn get_remote_url(remote: &str) -> String {
-        match Config::get("remote", Some(remote), "url").await {
+    // _with_conn version for get_remote_url
+    pub async fn get_remote_url_with_conn<C: ConnectionTrait>(db: &C, remote: &str) -> String {
+        match Config::get_with_conn(db, "remote", Some(remote), "url").await {
             Some(url) => url,
             None => panic!("fatal: No URL configured for remote '{remote}'."),
         }
     }
 
-    /// return `None` if no remote is set
-    pub async fn get_current_remote_url() -> Option<String> {
-        match Config::get_current_remote().await.unwrap() {
-            Some(remote) => Some(Config::get_remote_url(&remote).await),
+    // _with_conn version for get_current_remote_url
+    pub async fn get_current_remote_url_with_conn<C: ConnectionTrait>(db: &C) -> Option<String> {
+        match Config::get_current_remote_with_conn(db).await.unwrap() {
+            Some(remote) => Some(Config::get_remote_url_with_conn(db, &remote).await),
             None => None,
         }
     }
 
-    /// Get all configuration values
-    /// - e.g. remote.origin.url can be multiple
-    pub async fn get_all(configuration: &str, name: Option<&str>, key: &str) -> Vec<String> {
-        Self::query(configuration, name, key)
+    // _with_conn version for get_all
+    pub async fn get_all_with_conn<C: ConnectionTrait>(
+        db: &C,
+        configuration: &str,
+        name: Option<&str>,
+        key: &str,
+    ) -> Vec<String> {
+        Self::query_with_conn(db, configuration, name, key)
             .await
             .iter()
             .map(|c| c.value.to_owned())
             .collect()
     }
 
-    /// Get literally all the entries in database without any filtering
-    pub async fn list_all() -> Vec<(String, String)> {
-        let db = get_db_conn_instance().await;
+    // _with_conn version for list_all
+    pub async fn list_all_with_conn<C: ConnectionTrait>(db: &C) -> Vec<(String, String)> {
         config::Entity::find()
             .all(db)
             .await
@@ -141,16 +186,16 @@ impl Config {
             .collect()
     }
 
-    /// Delete one or all configuration using given key and value pattern
-    pub async fn remove_config(
+    // _with_conn version for remove_config
+    pub async fn remove_config_with_conn<C: ConnectionTrait>(
+        db: &C,
         configuration: &str,
         name: Option<&str>,
         key: &str,
         valuepattern: Option<&str>,
         delete_all: bool,
     ) {
-        let db = get_db_conn_instance().await;
-        let entries: Vec<Model> = Self::query(configuration, name, key).await;
+        let entries: Vec<Model> = Self::query_with_conn(db, configuration, name, key).await;
         for e in entries {
             let _res = match valuepattern {
                 Some(vp) => {
@@ -168,12 +213,11 @@ impl Config {
         }
     }
 
-    /// Delete all the configuration entries using given configuration field (--remove-section)
-    // pub async fn remove_by_section(configuration: &str) {
-    //     unimplemented!();
-    // }
-    pub async fn remove_remote(name: &str) -> Result<(), String> {
-        let db = get_db_conn_instance().await;
+    // _with_conn version for remove_remote
+    pub async fn remove_remote_with_conn<C: ConnectionTrait>(
+        db: &C,
+        name: &str,
+    ) -> Result<(), String> {
         let remote = config::Entity::find()
             .filter(config::Column::Configuration.eq("remote"))
             .filter(config::Column::Name.eq(name))
@@ -190,8 +234,8 @@ impl Config {
         Ok(())
     }
 
-    pub async fn all_remote_configs() -> Vec<RemoteConfig> {
-        let db = get_db_conn_instance().await;
+    // _with_conn version for all_remote_configs
+    pub async fn all_remote_configs_with_conn<C: ConnectionTrait>(db: &C) -> Vec<RemoteConfig> {
         let remotes = config::Entity::find()
             .filter(config::Column::Configuration.eq("remote"))
             .all(db)
@@ -219,8 +263,11 @@ impl Config {
             .collect()
     }
 
-    pub async fn remote_config(name: &str) -> Option<RemoteConfig> {
-        let db = get_db_conn_instance().await;
+    // _with_conn version for remote_config
+    pub async fn remote_config_with_conn<C: ConnectionTrait>(
+        db: &C,
+        name: &str,
+    ) -> Option<RemoteConfig> {
         let remote = config::Entity::find()
             .filter(config::Column::Configuration.eq("remote"))
             .filter(config::Column::Name.eq(name))
@@ -233,8 +280,11 @@ impl Config {
         })
     }
 
-    pub async fn branch_config(name: &str) -> Option<BranchConfig> {
-        let db = get_db_conn_instance().await;
+    // _with_conn version for branch_config
+    pub async fn branch_config_with_conn<C: ConnectionTrait>(
+        db: &C,
+        name: &str,
+    ) -> Option<BranchConfig> {
         let config_entries = config::Entity::find()
             .filter(config::Column::Configuration.eq("branch"))
             .filter(config::Column::Name.eq(name))
@@ -270,5 +320,96 @@ impl Config {
 
             Some(branch_config)
         }
+    }
+
+    pub async fn insert(configuration: &str, name: Option<&str>, key: &str, value: &str) {
+        let db = get_db_conn_instance().await;
+        Self::insert_with_conn(db, configuration, name, key, value).await;
+    }
+
+    // Update one configuration entry in database using given configuration, name, key and value
+    pub async fn update(configuration: &str, name: Option<&str>, key: &str, value: &str) -> Model {
+        let db = get_db_conn_instance().await;
+        Self::update_with_conn(db, configuration, name, key, value).await
+    }
+
+    /// Get one configuration value
+    pub async fn get(configuration: &str, name: Option<&str>, key: &str) -> Option<String> {
+        let db = get_db_conn_instance().await;
+        Self::get_with_conn(db, configuration, name, key).await
+    }
+
+    /// Get remote repo name by branch name
+    /// - You may need to `[branch::set-upstream]` if return `None`
+    pub async fn get_remote(branch: &str) -> Option<String> {
+        let db = get_db_conn_instance().await;
+        Self::get_remote_with_conn(db, branch).await
+    }
+
+    /// Get remote repo name of current branch
+    /// - `Error` if `HEAD` is detached
+    pub async fn get_current_remote() -> Result<Option<String>, ()> {
+        let db = get_db_conn_instance().await;
+        Self::get_current_remote_with_conn(db).await
+    }
+
+    pub async fn get_remote_url(remote: &str) -> String {
+        let db = get_db_conn_instance().await;
+        Self::get_remote_url_with_conn(db, remote).await
+    }
+
+    /// return `None` if no remote is set
+    pub async fn get_current_remote_url() -> Option<String> {
+        let db = get_db_conn_instance().await;
+        Self::get_current_remote_url_with_conn(db).await
+    }
+
+    /// Get all configuration values
+    /// - e.g. remote.origin.url can be multiple
+    pub async fn get_all(configuration: &str, name: Option<&str>, key: &str) -> Vec<String> {
+        let db = get_db_conn_instance().await;
+        Self::get_all_with_conn(db, configuration, name, key).await
+    }
+
+    /// Get literally all the entries in database without any filtering
+    pub async fn list_all() -> Vec<(String, String)> {
+        let db = get_db_conn_instance().await;
+        Self::list_all_with_conn(db).await
+    }
+
+    /// Delete one or all configuration using given key and value pattern
+    pub async fn remove_config(
+        configuration: &str,
+        name: Option<&str>,
+        key: &str,
+        valuepattern: Option<&str>,
+        delete_all: bool,
+    ) {
+        let db = get_db_conn_instance().await;
+        Self::remove_config_with_conn(db, configuration, name, key, valuepattern, delete_all).await;
+    }
+
+    /// Delete all the configuration entries using given configuration field (--remove-section)
+    // pub async fn remove_by_section(configuration: &str) {
+    //     unimplemented!();
+    // }
+    pub async fn remove_remote(name: &str) -> Result<(), String> {
+        let db = get_db_conn_instance().await;
+        Self::remove_remote_with_conn(db, name).await
+    }
+
+    pub async fn all_remote_configs() -> Vec<RemoteConfig> {
+        let db = get_db_conn_instance().await;
+        Self::all_remote_configs_with_conn(db).await
+    }
+
+    pub async fn remote_config(name: &str) -> Option<RemoteConfig> {
+        let db = get_db_conn_instance().await;
+        Self::remote_config_with_conn(db, name).await
+    }
+
+    pub async fn branch_config(name: &str) -> Option<BranchConfig> {
+        let db = get_db_conn_instance().await;
+        Self::branch_config_with_conn(db, name).await
     }
 }

--- a/libra/src/internal/head.rs
+++ b/libra/src/internal/head.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+use sea_orm::ConnectionTrait;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter};
 
@@ -15,73 +16,121 @@ pub enum Head {
     Branch(String),
 }
 
+/*
+ * =================================================================================
+ * NOTE: Transaction Safety Pattern (`_with_conn`)
+ * =================================================================================
+ *
+ * This module follows the `_with_conn` pattern for transaction safety.
+ *
+ * - Public functions (e.g., `get`, `update`) acquire a new database
+ *   connection from the pool and are suitable for single, non-transactional operations.
+ *
+ * - `*_with_conn` variants (e.g., `get_with_conn`, `update_with_conn`)
+ *   accept an existing connection or transaction handle (`&C where C: ConnectionTrait`).
+ *
+ * **WARNING**: To use these functions within a database transaction (e.g., inside
+ * a `db.transaction(|txn| { ... })` block), you MUST call the `*_with_conn`
+ * variant, passing the transaction handle `txn`. Calling a public version from
+ * inside a transaction will try to acquire a second connection from the pool,
+ * leading to a deadlock.
+ *
+ * Correct Usage (in a transaction): `Head::update_with_conn(txn, ...).await;`
+ * Incorrect Usage (in a transaction): `Head::update(...).await;` // DEADLOCK!
+ */
+
 impl Head {
-    async fn query_local_head() -> reference::Model {
-        let db_conn = get_db_conn_instance().await;
+    async fn query_local_head_with_conn<C>(db: &C) -> reference::Model
+    where
+        C: ConnectionTrait,
+    {
         reference::Entity::find()
             .filter(reference::Column::Kind.eq(reference::ConfigKind::Head))
             .filter(reference::Column::Remote.is_null())
-            .one(db_conn)
+            .one(db)
             .await
             .unwrap()
             .expect("fatal: storage broken, HEAD not found")
     }
 
-    async fn query_remote_head(remote: &str) -> Option<reference::Model> {
-        let db_conn = get_db_conn_instance().await;
+    async fn query_remote_head_with_conn<C>(db: &C, remote: &str) -> Option<reference::Model>
+    where
+        C: ConnectionTrait,
+    {
         reference::Entity::find()
             .filter(reference::Column::Kind.eq(reference::ConfigKind::Head))
             .filter(reference::Column::Remote.eq(remote))
-            .one(db_conn)
+            .one(db)
             .await
             .unwrap()
     }
 
-    pub async fn current() -> Head {
-        let head = Self::query_local_head().await;
+    pub async fn current_with_conn<C>(db: &C) -> Head
+    where
+        C: ConnectionTrait,
+    {
+        let head = Self::query_local_head_with_conn(db).await;
         match head.name {
             Some(name) => Head::Branch(name),
             None => {
-                // detached head
                 let commit_hash = head.commit.expect("detached head without commit");
                 Head::Detached(SHA1::from_str(commit_hash.as_str()).unwrap())
             }
         }
     }
 
-    pub async fn remote_current(remote: &str) -> Option<Head> {
-        match Self::query_remote_head(remote).await {
-            Some(head) => match head.name {
-                Some(name) => Some(Head::Branch(name)),
+    pub async fn current() -> Head {
+        let db_conn = get_db_conn_instance().await;
+        Self::current_with_conn(db_conn).await
+    }
+
+    pub async fn remote_current_with_conn<C>(db: &C, remote: &str) -> Option<Head>
+    where
+        C: ConnectionTrait,
+    {
+        match Self::query_remote_head_with_conn(db, remote).await {
+            Some(head) => Some(match head.name {
+                Some(name) => Head::Branch(name),
                 None => {
                     let commit_hash = head.commit.expect("detached head without commit");
-                    Some(Head::Detached(
-                        SHA1::from_str(commit_hash.as_str()).unwrap(),
-                    ))
+                    Head::Detached(SHA1::from_str(commit_hash.as_str()).unwrap())
                 }
-            },
+            }),
             None => None,
         }
     }
 
-    /// get the commit hash of the current head, return `None` if no commit
-    pub async fn current_commit() -> Option<SHA1> {
-        match Self::current().await {
+    pub async fn remote_current(remote: &str) -> Option<Head> {
+        let db_conn = get_db_conn_instance().await;
+        Self::remote_current_with_conn(db_conn, remote).await
+    }
+
+    pub async fn current_commit_with_conn<C>(db: &C) -> Option<SHA1>
+    where
+        C: ConnectionTrait,
+    {
+        match Self::current_with_conn(db).await {
             Head::Detached(commit_hash) => Some(commit_hash),
             Head::Branch(name) => {
-                let branch = Branch::find_branch(&name, None).await;
+                let branch = Branch::find_branch_with_conn(db, &name, None).await;
                 branch.map(|b| b.commit)
             }
         }
     }
 
-    // HEAD is unique, update if exists, insert if not
-    pub async fn update(new_head: Self, remote: Option<&str>) {
+    /// get the commit hash of current head, return `None` if no commit
+    pub async fn current_commit() -> Option<SHA1> {
         let db_conn = get_db_conn_instance().await;
+        Self::current_commit_with_conn(db_conn).await
+    }
 
+    pub async fn update_with_conn<C>(db: &C, new_head: Self, remote: Option<&str>)
+    where
+        C: ConnectionTrait,
+    {
         let head = match remote {
-            Some(remote) => Self::query_remote_head(remote).await,
-            None => Some(Self::query_local_head().await),
+            Some(remote) => Self::query_remote_head_with_conn(db, remote).await,
+            None => Some(Self::query_local_head_with_conn(db).await),
         };
         match head {
             Some(head) => {
@@ -100,10 +149,9 @@ impl Head {
                         head.commit = Set(None);
                     }
                 }
-                head.update(db_conn).await.unwrap();
+                head.update(db).await.unwrap();
             }
             None => {
-                // // insert
                 let mut head = reference::ActiveModel {
                     kind: Set(reference::ConfigKind::Head),
                     ..Default::default()
@@ -119,8 +167,14 @@ impl Head {
                         head.name = Set(Some(branch_name));
                     }
                 }
-                head.save(db_conn).await.unwrap();
+                head.save(db).await.unwrap();
             }
         }
+    }
+
+    // HEAD is unique, update if exists, insert if not
+    pub async fn update(new_head: Self, remote: Option<&str>) {
+        let db_conn = get_db_conn_instance().await;
+        Self::update_with_conn(db_conn, new_head, remote).await;
     }
 }


### PR DESCRIPTION
Previously, calling any database helper (e.g., Branch::update_branch) from within a db.transaction block would cause a deadlock, as the transaction held one connection while the helper function attempted to acquire a second one from the pool.

This has been resolved by implementing a consistent `_with_conn` pattern across all relevant modules(Head, Branch, Config).

Transaction-Safe Functions: Every function that touches the database now has a `*_with_conn` variant that accepts an existing database connection or transaction handle `(&C where C: ConnectionTrait)`.

Public API as Wrappers: The original public functions now act as simple wrappers, fetching a connection and calling their `_with_conn` counterpart, preserving the existing API for non-transactional use.