### PR TITLE
feat: Add conventional commit message check

### DIFF
--- a/ceres/src/merge_checker/commit_message_checker.rs
+++ b/ceres/src/merge_checker/commit_message_checker.rs
@@ -1,0 +1,38 @@
+use async_trait::async_trait;
+use jupiter::model::mr_dto::MrInfoDto;
+use serde_json::{json, Value};
+
+use crate::merge_checker::{CheckResult, CheckType, Checker, ConditionResult};
+use common::{errors::MegaError, utils::check_conventional_commits_message};
+
+pub struct CommitMessageChecker;
+
+#[async_trait]
+impl Checker for CommitMessageChecker {
+    async fn run(&self, params: &Value) -> CheckResult {
+        let title = params["title"].as_str().unwrap_or_default();
+        let status = if check_conventional_commits_message(title) {
+            ConditionResult::PASSED
+        } else {
+            ConditionResult::FAILED
+        };
+        let message = if status == ConditionResult::PASSED {
+            "Commit message follows conventional commits".to_string()
+        } else {
+            "Commit message does not follow conventional commits. Please make sure your MR title follows the Conventional Commits specification.".to_string()
+        };
+
+        CheckResult {
+            check_type_code: CheckType::CommitMessage,
+            status,
+            message,
+        }
+    }
+
+    async fn build_params(&self, mr_info: &MrInfoDto) -> Result<Value, MegaError> {
+        let title = mr_info.title.clone();
+        Ok(json!({
+            "title": title,
+        }))
+    }
+}

--- a/ceres/src/merge_checker/mod.rs
+++ b/ceres/src/merge_checker/mod.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use serde::Serialize;
 use utoipa::ToSchema;
 
+use crate::merge_checker::commit_message_checker::CommitMessageChecker;
 use crate::merge_checker::gpg_signature_checker::GpgSignatureChecker;
 use crate::merge_checker::mr_sync_checker::MrSyncChecker;
 use callisto::{check_result, sea_orm_active_enums::CheckTypeEnum};
@@ -11,6 +12,7 @@ use common::errors::MegaError;
 use jupiter::{model::mr_dto::MrInfoDto, storage::Storage};
 
 mod code_review_checker;
+mod commit_message_checker;
 mod gpg_signature_checker;
 pub mod mr_sync_checker;
 
@@ -152,6 +154,10 @@ impl CheckerRegistry {
             Box::new(code_review_checker::CodeReviewChecker {
                 storage: storage.clone(),
             }),
+        );
+        r.register(
+            CheckType::CommitMessage,
+            Box::new(CommitMessageChecker),
         );
 
         r


### PR DESCRIPTION
This PR adds a new check to the ceres merge process to ensure all merge request titles follow the Conventional Commits specification. This helps improve git history clarity and enables automated changelog generation.

The title is derived from the commit message.
```rust
let title = if let Some(commit) = commit_guard.as_ref() {
                    commit.format_message()
```