### PR TITLE
integration(mono): trigger Orion build from Mega

### DIFF
--- a/orion-server/bellatrix/src/orion_client/mod.rs
+++ b/orion-server/bellatrix/src/orion_client/mod.rs
@@ -1,12 +1,19 @@
 use serde::Serialize;
 
 #[derive(Serialize, Debug)]
-pub struct OrionBuildRequest {
-    pub repo: String,
+pub struct BuildInfo {
     pub buck_hash: String,
     pub buckconfig_hash: String,
-    pub mr: String,
     pub args: Option<Vec<String>>,
+}
+
+#[derive(Serialize, Debug)]
+pub struct OrionBuildRequest {
+    pub repo: String,
+    pub mr: i64,
+    pub task_name: Option<String>,
+    pub template: Option<String>,
+    pub builds: Vec<BuildInfo>,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
# Mega 与 Orion 构建触发集成

## 描述
本 PR 实现了 **Mega** 与 **Orion** 的集成，当 Mega 中的合并请求（MR）发生变化时，能够自动触发 Orion 构建。主要改动包括：

- 修复了task api变动导致的接口调用问题。

## 关联问题
#1507

## 相关人员
- @zyd123-cmd