### PR TITLE
fix: update build parameters

### DIFF
--- a/ceres/src/pack/monorepo.rs
+++ b/ceres/src/pack/monorepo.rs
@@ -533,6 +533,7 @@ impl MonoRepo {
                 for buck_file in buck_files {
                     let req = OrionBuildRequest {
                         repo: buck_file.path.to_str().unwrap().to_string(),
+                        cl_link: link.to_string(),
                         cl: cl_info.id,
                         task_name: None,
                         template: None,

--- a/jupiter/callisto/src/tasks.rs
+++ b/jupiter/callisto/src/tasks.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: Uuid,
-    pub mr_id: i64,
+    pub cl_id: i64,
     pub task_name: Option<String>,
     #[sea_orm(column_type = "JsonBinary", nullable)]
     pub template: Option<Json>,

--- a/jupiter/src/migration/m20251011_091944_tasks_mr_id_to_cl_id.rs
+++ b/jupiter/src/migration/m20251011_091944_tasks_mr_id_to_cl_id.rs
@@ -1,0 +1,30 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Tasks::Table)
+                    .rename_column(Tasks::MrId, Tasks::ClId)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, _: &SchemaManager) -> Result<(), DbErr> {
+        // Replace the sample below with your own migration scripts
+        todo!();
+    }
+}
+
+#[derive(DeriveIden)]
+enum Tasks {
+    Table,
+    MrId,
+    ClId,
+}

--- a/jupiter/src/migration/mod.rs
+++ b/jupiter/src/migration/mod.rs
@@ -60,6 +60,7 @@ mod m20250904_120000_add_commit_auths;
 mod m20250905_163011_add_mr_reviewer;
 mod m20250910_153212_add_username_to_reviewer;
 mod m20250930_024736_mr_to_cl;
+mod m20251011_091944_tasks_mr_id_to_cl_id;
 
 /// Creates a primary key column definition with big integer type.
 ///
@@ -108,6 +109,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20250905_163011_add_mr_reviewer::Migration),
             Box::new(m20250910_153212_add_username_to_reviewer::Migration),
             Box::new(m20250930_024736_mr_to_cl::Migration),
+            Box::new(m20251011_091944_tasks_mr_id_to_cl_id::Migration),
         ]
     }
 }

--- a/orion-server/SCHEDULER_README.md
+++ b/orion-server/SCHEDULER_README.md
@@ -137,7 +137,7 @@ let config = SchedulerConfig {
 ### Priority Determination
 
 The system automatically determines task priority based on:
-- **Merge Request labels**: `hotfix`, `urgent`, `critical` → Critical priority
+- **Change List labels**: `hotfix`, `urgent`, `critical` → Critical priority
 - **Repository importance**: `core`, `main`, `production` → High priority
 - **Build complexity**: Fewer arguments → Higher priority (faster feedback)
 - **System load**: High load → Lower priority for complex tasks

--- a/orion-server/bellatrix/src/orion_client/mod.rs
+++ b/orion-server/bellatrix/src/orion_client/mod.rs
@@ -9,6 +9,7 @@ pub struct BuildInfo {
 
 #[derive(Serialize, Debug)]
 pub struct OrionBuildRequest {
+    pub cl_link: String,
     pub repo: String,
     pub cl: i64,
     pub task_name: Option<String>,

--- a/orion-server/db/schema.sql
+++ b/orion-server/db/schema.sql
@@ -3,7 +3,7 @@
 -- Table Definition
 CREATE TABLE "public"."tasks" (
     "id" uuid NOT NULL,
-    "mr_id" int8 NOT NULL,
+    "cl_id" int8 NOT NULL,
     "task_name" varchar,
     "template" jsonb,
     "created_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/orion-server/src/model/builds.rs
+++ b/orion-server/src/model/builds.rs
@@ -48,13 +48,13 @@ impl ActiveModelBehavior for ActiveModel {}
 impl Model {
     /// Create a new build ActiveModel for database insertion
     pub fn create_build(
+        build_id: Uuid,
         task_id: Uuid,
         repo: String,
         target: String,
         args: Option<Value>,
     ) -> ActiveModel {
         let now = Utc::now().into();
-        let build_id = Uuid::now_v7();
         ActiveModel {
             id: Set(build_id),
             task_id: Set(task_id),
@@ -71,13 +71,20 @@ impl Model {
 
     /// Insert a single build directly into the database
     pub async fn insert_build(
+        build_id: Uuid,
         task_id: Uuid,
         repo: String,
         target: String,
         build: BuildRequest,
         db: &impl ConnectionTrait,
     ) -> Result<Model, DbErr> {
-        let build_model = Self::create_build(task_id, repo, target, build.args.map(|a| json!(a)));
+        let build_model = Self::create_build(
+            build_id,
+            task_id,
+            repo,
+            target,
+            build.args.map(|a| json!(a)),
+        );
         build_model.insert(db).await
     }
 }

--- a/orion-server/src/model/tasks.rs
+++ b/orion-server/src/model/tasks.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: Uuid,
-    pub mr_id: i64,
+    pub cl_id: i64,
     pub task_name: Option<String>,
     #[sea_orm(column_type = "JsonBinary", nullable)]
     pub template: Option<Json>,
@@ -58,14 +58,14 @@ impl Model {
     /// Create a new task ActiveModel for database insertion
     pub fn create_task(
         task_id: Uuid,
-        mr_id: i64,
+        cl_id: i64,
         task_name: Option<String>,
         template: Option<Json>,
         created_at: DateTimeWithTimeZone,
     ) -> ActiveModel {
         ActiveModel {
             id: Set(task_id),
-            mr_id: Set(mr_id),
+            cl_id: Set(cl_id),
             task_name: Set(task_name),
             template: Set(template),
             created_at: Set(created_at),
@@ -75,13 +75,13 @@ impl Model {
     /// Insert a task directly into the database
     pub async fn insert_task(
         task_id: Uuid,
-        mr_id: i64,
+        cl_id: i64,
         task_name: Option<String>,
         template: Option<Json>,
         created_at: DateTimeWithTimeZone,
         db: &impl ConnectionTrait,
     ) -> Result<Model, DbErr> {
-        let task_model = Self::create_task(task_id, mr_id, task_name, template, created_at);
+        let task_model = Self::create_task(task_id, cl_id, task_name, template, created_at);
         task_model.insert(db).await
     }
 }

--- a/orion/src/api.rs
+++ b/orion/src/api.rs
@@ -13,8 +13,8 @@ pub struct BuildRequest {
     pub target: String,
     /// Additional command-line arguments for the build
     pub args: Option<Vec<String>>,
-    /// Merge request identifier for context
-    pub mr: String,
+    /// Change List identifier for context
+    pub cl: String,
 }
 
 /// Result of a build operation containing status and metadata.
@@ -59,7 +59,7 @@ pub async fn buck_build(
             req.repo,
             req.target,
             req.args.unwrap_or_default(),
-            req.mr,
+            req.cl,
             sender.clone(),
         )
         .await

--- a/orion/src/buck_controller.rs
+++ b/orion/src/buck_controller.rs
@@ -19,14 +19,14 @@ static PROJECT_ROOT: Lazy<String> =
 ///
 /// # Arguments
 /// * `repo` - Repository path to mount
-/// * `mr` - Merge request identifier
+/// * `cl` - Change List identifier
 ///
 /// # Returns
 /// * `Ok(true)` - Mount operation completed successfully
 /// * `Err(_)` - Mount request failed or timed out
-pub async fn mount_fs(repo: &str, mr: &str) -> Result<bool, Box<dyn Error + Send + Sync>> {
+pub async fn mount_fs(repo: &str, cl: &str) -> Result<bool, Box<dyn Error + Send + Sync>> {
     let client = reqwest::Client::new();
-    let mount_payload = json!({ "path": repo, "mr": mr });
+    let mount_payload = json!({ "path": repo, "cl": cl });
 
     let mount_res = client
         .post("http://localhost:2725/api/fs/mount")
@@ -125,7 +125,7 @@ pub async fn mount_fs(repo: &str, mr: &str) -> Result<bool, Box<dyn Error + Send
 /// * `repo` - Repository path for filesystem mounting
 /// * `target` - Buck build target specification  
 /// * `args` - Additional command-line arguments for buck
-/// * `mr` - Merge request context identifier
+/// * `cl` - Change List context identifier
 /// * `sender` - WebSocket channel for streaming build output
 ///
 /// # Returns
@@ -135,7 +135,7 @@ pub async fn build(
     repo: String,
     target: String,
     args: Vec<String>,
-    mr: String,
+    cl: String,
     sender: UnboundedSender<WSMessage>,
 ) -> Result<ExitStatus, Box<dyn Error + Send + Sync>> {
     tracing::info!(
@@ -145,7 +145,7 @@ pub async fn build(
         repo
     );
 
-    mount_fs(&repo, &mr).await?;
+    mount_fs(&repo, &cl).await?;
     tracing::info!("[Task {}] Filesystem mounted successfully.", id);
 
     let mut cmd = Command::new("buck2");

--- a/orion/src/ws.rs
+++ b/orion/src/ws.rs
@@ -41,7 +41,7 @@ pub enum WSMessage {
         repo: String,
         target: String,
         args: Option<Vec<String>>,
-        mr: String,
+        cl_link: String,
     },
 }
 
@@ -193,7 +193,7 @@ async fn process_server_message(
                             repo,
                             target,
                             args,
-                            mr,
+                            cl_link: cl,
                         } => {
                             tracing::info!("Received task: id={}", id);
                             tokio::spawn(async move {
@@ -215,7 +215,7 @@ async fn process_server_message(
                                         repo,
                                         target,
                                         args,
-                                        mr,
+                                        cl,
                                     },
                                     sender.clone(),
                                 )

--- a/scorpio/src/daemon/mod.rs
+++ b/scorpio/src/daemon/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::fuse::MegaFuse;
 use crate::manager::fetch::fetch;
-use crate::manager::{mr, ScorpioManager, WorkDir};
+use crate::manager::{cl, ScorpioManager, WorkDir};
 use crate::util::{config, GPath};
 use axum::extract::{Path, State};
 use axum::routing::{get, post};
@@ -20,7 +20,7 @@ const FAIL: &str = "Fail";
 #[derive(Debug, Deserialize, Serialize, Clone)]
 struct MountRequest {
     path: String,
-    mr: Option<String>, // mr is the mount request, used for buck2 temp mount.
+    cl: Option<String>, // cl is the mount request, used for buck2 temp mount.
 }
 
 /// Response structure for mount requests.
@@ -37,7 +37,7 @@ struct MountResponse {
 struct MountStatus {
     request_id: String,        // Unique identifier for the mount request
     status: String,            // Current task status: "fetching", "finished", or "error"
-    mount_info: MountRequest,  // Original mount request containing path and mr info
+    mount_info: MountRequest,  // Original mount request containing path and cl info
     result: Option<MountInfo>, // Mount result populated when task completes successfully
 }
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
@@ -262,18 +262,18 @@ async fn perform_mount_task(state: ScoState, req: MountRequest) -> Result<MountI
         .map_err(|e| format!("Failed to fetch: {e}"))?;
     let store_path = PathBuf::from(store_path).join(&work_dir.hash);
 
-    // Handle merge request (MR) layer if provided
-    if let Some(m) = &req.mr {
-        let mr_store_path = PathBuf::from(&store_path).join("mr");
-        if let Err(e) = mr::build_mr_layer(m, mr_store_path).await {
-            return Err(format!("Failed to build mr layer: {e}"));
+    // Handle Change List (CL) layer if provided
+    if let Some(m) = &req.cl {
+        let cl_store_path = PathBuf::from(&store_path).join("cl");
+        if let Err(e) = cl::build_cl_layer(m, cl_store_path).await {
+            return Err(format!("Failed to build cl layer: {e}"));
         }
     }
 
-    // Perform the final overlay mount with MR layer if applicable
+    // Perform the final overlay mount with CL layer if applicable
     state
         .fuse
-        .overlay_mount(inode, store_path, req.mr.is_some())
+        .overlay_mount(inode, store_path, req.cl.is_some())
         .await
         .map_err(|e| format!("Mount process error: {e}"))?;
 

--- a/scorpio/src/fuse/mod.rs
+++ b/scorpio/src/fuse/mod.rs
@@ -95,15 +95,15 @@ impl MegaFuse {
         &self,
         inode: u64,
         store_path: P,
-        need_mr: bool, // if need mr, then create mr layer.
+        need_cl: bool, // if need cl, then create cl layer.
     ) -> std::io::Result<()> {
         let lower = store_path.as_ref().join("lower");
         let upper = store_path.as_ref().join("upper");
         let mut lowerdir = vec![lower];
-        if need_mr {
-            let mr_path = store_path.as_ref().join("mr");
-            let _ = std::fs::create_dir_all(&mr_path);
-            lowerdir.push(mr_path);
+        if need_cl {
+            let cl_path = store_path.as_ref().join("cl");
+            let _ = std::fs::create_dir_all(&cl_path);
+            lowerdir.push(cl_path);
         }
         let upperdir = upper;
 

--- a/scorpio/src/manager/fetch.rs
+++ b/scorpio/src/manager/fetch.rs
@@ -327,13 +327,13 @@ pub fn enqueue_file_download(file_id: SHA1, save_path: PathBuf) {
     }
 }
 
-/// Download multiple files for MR scenarios.
-pub async fn download_mr_files(
+/// Download multiple files for CL scenarios.
+pub async fn download_cl_files(
     files: Vec<(SHA1, PathBuf)>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let download_manager = DownloadManager::get_global();
 
-    // Since this is for MR files only (no directory traversal),
+    // Since this is for CL files only (no directory traversal),
     // we mark directory processing as complete immediately
     download_manager.notify_directory_processing_complete();
 

--- a/scorpio/src/manager/mod.rs
+++ b/scorpio/src/manager/mod.rs
@@ -16,10 +16,10 @@ use std::io::Write;
 use std::{fs, path::PathBuf, str::FromStr};
 
 pub mod add;
+pub mod cl;
 pub mod commit;
 pub mod diff;
 pub mod fetch;
-pub mod mr;
 pub mod push;
 pub mod reset;
 pub mod status;


### PR DESCRIPTION
## 描述
本 PR 更新了构建参数，以修复构建过程中的问题。主要修改包括：

- 调整 orion-server的task接口参数，新增了cl_link字段。
- 修改了orion-server向orion传递的ws包参数，cl由原本的cl_id改为cl_link。
- 修改了orion-server的bellatrix模块，新增了cl_link字段。
- 迁移tasks数据表字段mr_id为cl_id
- 迁移了mono、orion-server、orion、scorpio的所有mr相关字段到cl。

## 关联 Issues
#1507 
