### PR TITLE
feat: add tag menu to tag navigation

### DIFF
--- a/moon/apps/web/components/Sidebar/SidebarTags.tsx
+++ b/moon/apps/web/components/Sidebar/SidebarTags.tsx
@@ -1,0 +1,22 @@
+import router from 'next/router'
+
+import { SidebarLink } from './SidebarLink'
+import { useScope } from '@/contexts/scope'
+import { TagIcon } from '@gitmono/ui/Icons'
+
+export function SidebarTags() {
+  const { scope } = useScope()
+  
+  return (
+   <>
+     <SidebarLink
+        id='tags'
+        label='Tags'
+        href={`/${scope}/code/tags`}
+        active={router.pathname === '/[org]/code/tags'}
+        leadingAccessory={<TagIcon />}
+      />
+   </>
+  )
+}
+

--- a/moon/apps/web/components/Sidebar/index.tsx
+++ b/moon/apps/web/components/Sidebar/index.tsx
@@ -41,6 +41,7 @@ import { SidebarGroup } from './SidebarGroup'
 import { SidebarInbox } from './SidebarInbox'
 import { SiderbarChangeList } from './SiderbarChangeList'
 import { SidebarCratespro } from './SidebarCratespro'
+import { SidebarTags } from './SidebarTags'
 
 export function SidebarContainer() {
   const { scope } = useScope()
@@ -167,6 +168,7 @@ function SidebarContent() {
           <SidebarMyWorkItems />
           <SidebarDrafts />
           <SidebarCode />
+          <SidebarTags />
           <SiderbarChangeList />
           <SidebarIssue />
           <SidebarCratespro />

--- a/moon/apps/web/pages/[org]/code/tree/[...path]/index.tsx
+++ b/moon/apps/web/pages/[org]/code/tree/[...path]/index.tsx
@@ -88,7 +88,7 @@ function TreeDetailPage() {
           {!isNewCode ? (
             <>
               <div className='m-1 flex justify-end gap-2'>
-                <TagSwitcher />
+                {refs && <TagSwitcher />}
                 <Button onClick={() => handleNewClick('file')}>New File</Button>
                 <Button onClick={() => handleNewClick('folder')}>New Folder</Button>
                 {canClone?.data && <CloneTabs />}


### PR DESCRIPTION
- On the Tags page, call the tree API to fetch the first directory as the default path
- Hide the Tag button when entering via the Code menu
- Pass `defaultPath` from parent component to `MonoTagList`
- Fix incorrect link in the original Tag button jump