### PR TITLE
refactor: Change tags/refs from query parameters to path parameters

### DIFF
--- a/moon/apps/web/components/CodeView/CodeTable.tsx
+++ b/moon/apps/web/components/CodeView/CodeTable.tsx
@@ -25,7 +25,7 @@ const CodeTable = ({ directory, loading, readmeContent }: any) => {
   const router = useRouter()
   const pathname = usePathname()
   const nextRouter = useNextRouter()
-  
+
   const refs = (nextRouter.query.version as string) || 'main'
 
   let real_path = pathname?.replace('/tree', '')
@@ -89,7 +89,6 @@ const CodeTable = ({ directory, loading, readmeContent }: any) => {
         pathParts?.splice(2, 0, 'blob')
       }
 
-      // 插入 version 参数
       if (pathParts.length >= 3 && pathParts[2] === 'blob') {
         pathParts.splice(3, 0, refs)
       }
@@ -105,7 +104,6 @@ const CodeTable = ({ directory, loading, readmeContent }: any) => {
         pathParts?.splice(2, 0, 'tree')
       }
 
-      // 插入 version 参数
       if (pathParts.length >= 3 && pathParts[2] === 'tree') {
         pathParts.splice(3, 0, refs)
       }

--- a/moon/apps/web/components/CodeView/NewCodeView/NewCodeView.tsx
+++ b/moon/apps/web/components/CodeView/NewCodeView/NewCodeView.tsx
@@ -19,9 +19,10 @@ interface NewCodeViewProps {
   currentPath?: string
   onClose?: () => void
   defaultType?: 'folder' | 'file'
+  version?: string 
 }
 
-const NewCodeView = ({ currentPath = '', onClose, defaultType = 'file' }: NewCodeViewProps) => {
+const NewCodeView = ({ currentPath = '', onClose, defaultType = 'file', version }: NewCodeViewProps) => {
   const router = useRouter()
   const { scope } = useScope()
   const queryClient = useQueryClient()
@@ -78,9 +79,9 @@ const NewCodeView = ({ currentPath = '', onClose, defaultType = 'file' }: NewCod
           ])
 
           if (fileType === 'file') {
-            router.push(`/${scope}/code/blob${fullPath}`)
+            router.push(`/${scope}/code/blob/${version}${fullPath}`)
           } else {
-            router.push(`/${scope}/code/tree${fullPath}`)
+            router.push( `/${scope}/code/tree/${version}${fullPath}`)
           }
 
           onClose?.()

--- a/moon/apps/web/components/CodeView/TreeView/BreadCrumb.tsx
+++ b/moon/apps/web/components/CodeView/TreeView/BreadCrumb.tsx
@@ -1,51 +1,50 @@
-import React from 'react';
-import 'github-markdown-css/github-markdown-light.css'
-import { useRouter } from 'next/router';
-import { BreadcrumbLabel } from '@/components/Titlebar/BreadcrumbTitlebar'
-import { Link } from '@gitmono/ui'
-import { UrlObject } from 'url';
-import { useRefsFromRouter } from '@/hooks/useRefsFromRouter'
+import React from 'react'
 
-const Breadcrumb = ({ path }:any) => {
-  const router = useRouter();
+import 'github-markdown-css/github-markdown-light.css'
+
+import { UrlObject } from 'url'
+import { useRouter } from 'next/router'
+
+import { Link } from '@gitmono/ui'
+
+import { BreadcrumbLabel } from '@/components/Titlebar/BreadcrumbTitlebar'
+
+const Breadcrumb = ({ path }: any) => {
+  const router = useRouter()
   const scope = router.query.org as string
-  const { refs } = useRefsFromRouter()
-  
+  const refs = router.query.version as string
+
   const breadCrumbItems = path?.map((subPath: any, index: number) => {
-    const href = `/${scope}/code/tree/${path.slice(0, index + 1).join('/')}${refs ? `?refs=${encodeURIComponent(refs)}` : ''}`;
+    const pathPart = path.slice(0, index + 1).join('/')
+    const href = `/${scope}/code/tree/${refs}/${pathPart}`
 
     return {
       title: subPath,
       href: href,
-      isLast: index === path.length - 1,
-    };
-  });
+      isLast: index === path.length - 1
+    }
+  })
 
-    return (
-  <div className='flex items-center overflow-x-auto p-3 no-scrollbar gap-2'>
-
-        {breadCrumbItems?.map((item: { isLast: any; title: string; href: string | UrlObject; }, index: number) => (
+  return (
+    <div className='no-scrollbar flex items-center gap-2 overflow-x-auto p-3'>
+      {breadCrumbItems?.map((item: { isLast: any; title: string; href: string | UrlObject }, index: number) => (
         <React.Fragment key={item.title}>
           {/* displayed after the home item and before non-last items */}
-          {index > 0 && (
-            <span className="text-gray-400">/</span>
-          )}
+          {index > 0 && <span className='text-gray-400'>/</span>}
           {/* Current breadcrumb item */}
           {item.isLast ? (
             // last item
-            <BreadcrumbLabel>
-              {item?.title}
-            </BreadcrumbLabel>
+            <BreadcrumbLabel>{item?.title}</BreadcrumbLabel>
           ) : (
             // middle item
-            <Link href={item?.href} >
+            <Link href={item?.href}>
               <BreadcrumbLabel>{item?.title}</BreadcrumbLabel>
             </Link>
           )}
         </React.Fragment>
-))}
-      </div>
-    );
-};
+      ))}
+    </div>
+  )
+}
 
-export default Breadcrumb;
+export default Breadcrumb

--- a/moon/apps/web/components/CodeView/TreeView/RepoTree.tsx
+++ b/moon/apps/web/components/CodeView/TreeView/RepoTree.tsx
@@ -1,181 +1,202 @@
-import * as React from 'react';
-import { useCallback, useEffect, useState, useRef } from 'react';
-import { Box, Skeleton } from '@mui/material';
-import { RichTreeView } from '@mui/x-tree-view/RichTreeView';
-import { usePathname } from 'next/navigation';
-import { useRouter } from 'next/router';
-import { useGetTree } from '@/hooks/useGetTree';
-import { useRefsFromRouter } from '@/hooks/useRefsFromRouter';
-import { legacyApiClient } from '@/utils/queryClient';
-import { convertToTreeData, generateExpandedPaths, mergeTreeNodes, findNode, getDescendantIds, MuiTreeNode } from './TreeUtils';
-import { CustomTreeItem } from './CustomTreeItem';
-import toast from 'react-hot-toast';
-import { useAtom } from 'jotai';
-import { expandedNodesAtom, treeAllDataAtom } from './codeTreeAtom';
-import { useTreeViewApiRef } from "@mui/x-tree-view";
+import * as React from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Box, Skeleton } from '@mui/material'
+import { useTreeViewApiRef } from '@mui/x-tree-view'
+import { RichTreeView } from '@mui/x-tree-view/RichTreeView'
+import { useAtom } from 'jotai'
+import { usePathname } from 'next/navigation'
+import { useRouter } from 'next/router'
+import toast from 'react-hot-toast'
 
-const RepoTree = ({ onCommitInfoChange }: { onCommitInfoChange?:Function }) => {
-  const router = useRouter();
-  const scope = router.query.org as string;
-  const pathname = usePathname();
-  const basePath = pathname?.replace(
-    new RegExp(`\\/${scope}\\/code\\/(tree|blob)`), 
-    ''
-  ) || '/';
+import { useGetTree } from '@/hooks/useGetTree'
+import { legacyApiClient } from '@/utils/queryClient'
 
-  const apiRef = useTreeViewApiRef();
+import { expandedNodesAtom, treeAllDataAtom } from './codeTreeAtom'
+import { CustomTreeItem } from './CustomTreeItem'
+import {
+  convertToTreeData,
+  findNode,
+  generateExpandedPaths,
+  getDescendantIds,
+  mergeTreeNodes,
+  MuiTreeNode
+} from './TreeUtils'
+
+const RepoTree = ({ onCommitInfoChange }: { onCommitInfoChange?: Function }) => {
+  const router = useRouter()
+  const scope = router.query.org as string
+  const pathname = usePathname()
+
+  const version = router.query.version as string
+
+  let basePath = pathname?.replace(new RegExp(`\\/${scope}\\/code\\/(tree|blob)`), '') || '/'
+
+  if (version && basePath.startsWith(`/${version}`)) {
+    basePath = basePath.substring(`/${version}`.length) || '/'
+  }
+
+  const apiRef = useTreeViewApiRef()
 
   const [treeAllData, setTreeAllData] = useAtom(treeAllDataAtom)
   const [expandedNodes, setExpandedNodes] = useAtom(expandedNodesAtom)
-  const [loadingDirectories, setLoadingDirectories] = useState<Set<string>>(new Set());
-  
-  const { refs } = useRefsFromRouter();
-  const { data: treeItems, isLoading: isTreeLoading } = useGetTree({ path: basePath, ...(refs ? { refs } : {}) });
-  
-  const prevRefsRef = useRef<string | undefined>(refs);
-  const loadingRequestsRef = useRef<Set<string>>(new Set());
-  const treeAllDataRef = useRef<MuiTreeNode[]>(treeAllData);
-  
-  useEffect(() => {
-    treeAllDataRef.current = treeAllData;
-  }, [treeAllData]);
+  const [loadingDirectories, setLoadingDirectories] = useState<Set<string>>(new Set())
+
+  const refs = version === 'main' ? undefined : version
+  const { data: treeItems, isLoading: isTreeLoading } = useGetTree({ path: basePath, ...(refs ? { refs } : {}) })
+
+  const prevRefsRef = useRef<string | undefined>(refs)
+  const loadingRequestsRef = useRef<Set<string>>(new Set())
+  const treeAllDataRef = useRef<MuiTreeNode[]>(treeAllData)
 
   useEffect(() => {
-    const refsChanged = prevRefsRef.current !== refs;
-    
+    treeAllDataRef.current = treeAllData
+  }, [treeAllData])
+
+  useEffect(() => {
+    const refsChanged = prevRefsRef.current !== refs
+
     if (refsChanged) {
-      setTreeAllData([]);
-      setExpandedNodes(generateExpandedPaths(basePath));
-      setLoadingDirectories(new Set([basePath]));
-      
-      prevRefsRef.current = refs;
+      setTreeAllData([])
+      setExpandedNodes(generateExpandedPaths(basePath))
+      setLoadingDirectories(new Set([basePath]))
+
+      prevRefsRef.current = refs
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refs]);
+  }, [refs])
 
   useEffect(() => {
-    const pathsToExpand = generateExpandedPaths(basePath);
-    const existingNode = findNode(treeAllData, basePath);
-    const hasRealData = existingNode?.children && !existingNode?.children[0]?.isPlaceholder;
-    
+    const pathsToExpand = generateExpandedPaths(basePath)
+    const existingNode = findNode(treeAllData, basePath)
+    const hasRealData = existingNode?.children && !existingNode?.children[0]?.isPlaceholder
+
     if (
       !loadingDirectories.has(basePath) &&
       (!existingNode || existingNode?.content_type === 'directory') &&
       !hasRealData
     ) {
-      setLoadingDirectories(prev => new Set(prev).add(basePath));
+      setLoadingDirectories((prev) => new Set(prev).add(basePath))
     }
-    
-    setExpandedNodes(Array.from(new Set([...pathsToExpand])));
+
+    setExpandedNodes(Array.from(new Set([...pathsToExpand])))
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [basePath]);
+  }, [basePath])
 
   useEffect(() => {
     if (treeItems) {
-      const newPathTreeData = convertToTreeData(treeItems);
-      const merged = mergeTreeNodes(treeAllDataRef.current, newPathTreeData);
+      const newPathTreeData = convertToTreeData(treeItems)
+      const merged = mergeTreeNodes(treeAllDataRef.current, newPathTreeData)
 
-      setTreeAllData(merged);
+      setTreeAllData(merged)
     }
-  }, [setTreeAllData, treeItems]);
+  }, [setTreeAllData, treeItems])
 
+  const handleNodeToggle = useCallback(
+    (_event: React.SyntheticEvent | null, nodeIds: string[]) => {
+      const collapsedNodes = expandedNodes.filter((id) => !nodeIds.includes(id))
 
-const handleNodeToggle = useCallback((_event: React.SyntheticEvent | null, nodeIds: string[]) => {
-  const collapsedNodes = expandedNodes.filter(id => !nodeIds.includes(id));
-  
-  let newExpandedIds = [...nodeIds];
-  
-  if (collapsedNodes.length > 0) {
-    collapsedNodes.forEach(collapsedId => {
-      const descendantIds = getDescendantIds(treeAllData, collapsedId);
-      
-      newExpandedIds = newExpandedIds.filter(id => !descendantIds.includes(id));
-    });
-  }
-  
-  const newlyExpandedIds = newExpandedIds.filter(id => !expandedNodes.includes(id));
-  
-  newlyExpandedIds.forEach(nodeId => {
-    const existingNode = findNode(treeAllData, nodeId);
-    const hasRealData = existingNode?.children && !existingNode?.children[0].isPlaceholder;
-    
-    if (!loadingDirectories.has(nodeId) && !hasRealData) {
-      setLoadingDirectories(prev => new Set(prev).add(nodeId));
-    }
-  });
+      let newExpandedIds = [...nodeIds]
 
-  setExpandedNodes(newExpandedIds);
-}, [expandedNodes, loadingDirectories, treeAllData, setLoadingDirectories, setExpandedNodes]);
+      if (collapsedNodes.length > 0) {
+        collapsedNodes.forEach((collapsedId) => {
+          const descendantIds = getDescendantIds(treeAllData, collapsedId)
+
+          newExpandedIds = newExpandedIds.filter((id) => !descendantIds.includes(id))
+        })
+      }
+
+      const newlyExpandedIds = newExpandedIds.filter((id) => !expandedNodes.includes(id))
+
+      newlyExpandedIds.forEach((nodeId) => {
+        const existingNode = findNode(treeAllData, nodeId)
+        const hasRealData = existingNode?.children && !existingNode?.children[0].isPlaceholder
+
+        if (!loadingDirectories.has(nodeId) && !hasRealData) {
+          setLoadingDirectories((prev) => new Set(prev).add(nodeId))
+        }
+      })
+
+      setExpandedNodes(newExpandedIds)
+    },
+    [expandedNodes, loadingDirectories, treeAllData, setLoadingDirectories, setExpandedNodes]
+  )
 
   useEffect(() => {
-    loadingDirectories.forEach(path => {
-      const requestKey = `${path}:${refs || 'default'}`;
-      
+    loadingDirectories.forEach((path) => {
+      const requestKey = `${path}:${refs || 'default'}`
+
       if (loadingRequestsRef.current.has(requestKey)) {
-        return;
+        return
       }
-      
-      loadingRequestsRef.current.add(requestKey);
-      
-      const params: any = { path };
 
-      if (refs) params.refs = refs;
-      
-      legacyApiClient.v1.getApiTree().request(params)
+      loadingRequestsRef.current.add(requestKey)
+
+      const params: any = { path }
+
+      if (refs) params.refs = refs
+
+      legacyApiClient.v1
+        .getApiTree()
+        .request(params)
         .then((response: any) => {
-          if (response) {   
-            const newDirectoryData = convertToTreeData(response);
-            
-            const merged = mergeTreeNodes(treeAllDataRef.current, newDirectoryData);
+          if (response) {
+            const newDirectoryData = convertToTreeData(response)
 
-            setTreeAllData(merged);
+            const merged = mergeTreeNodes(treeAllDataRef.current, newDirectoryData)
+
+            setTreeAllData(merged)
           }
         })
         .catch((_error: any) => {
-          toast.error('Loading failed.');
+          toast.error('Loading failed.')
         })
         .finally(() => {
-          loadingRequestsRef.current.delete(requestKey);
-          setLoadingDirectories(prev => {
-            const newSet = new Set(prev);
+          loadingRequestsRef.current.delete(requestKey)
+          setLoadingDirectories((prev) => {
+            const newSet = new Set(prev)
 
-            newSet.delete(path);
-            return newSet;
-          });
-        });
-    });
-  }, [loadingDirectories, refs, setTreeAllData]);
+            newSet.delete(path)
+            return newSet
+          })
+        })
+    })
+  }, [loadingDirectories, refs, setTreeAllData])
 
-  const handleLabelClick = useCallback((path: string, isDirectory: boolean) => {
-    if (isDirectory) {
-      const fullPath = `/${scope}/code/tree${path}${refs ? `?refs=${encodeURIComponent(refs)}` : ''}`;
-      const cleanPath = fullPath.replace(/\/+/g, '/');
-      
-      router.push(cleanPath);
-    } else {      
-      const filePath = path.startsWith('/') ? path : `/${path}`;
+  const handleLabelClick = useCallback(
+    (path: string, isDirectory: boolean) => {
+      if (isDirectory) {
+        const fullPath = `/${scope}/code/tree/${version}${path}`
+        const cleanPath = fullPath.replace(/\/+/g, '/')
 
-      router.push(`/${scope}/code/blob${filePath}${refs ? `?refs=${encodeURIComponent(refs)}` : ''}`);
-    }
-  }, [router, scope, refs]);
+        router.push(cleanPath)
+      } else {
+        const filePath = path.startsWith('/') ? path : `/${path}`
+
+        const blobPath = `/${scope}/code/blob/${version}${filePath}`
+
+        router.push(blobPath)
+      }
+    },
+    [router, scope, version]
+  )
 
   const handleFocusItem = (_e: React.SyntheticEvent | null, itemId: string) => {
     const item = apiRef.current!.getItem(itemId)
 
     if (item.content_type) {
-      handleLabelClick(item.path, item.content_type === 'directory');
+      handleLabelClick(item.path, item.content_type === 'directory')
       apiRef.current?.setItemSelection({
         itemId,
         keepExistingSelection: false
       })
     }
   }
-  
-   useEffect(() => {
+
+  useEffect(() => {
     if (basePath) {
-      onCommitInfoChange?.(basePath);
+      onCommitInfoChange?.(basePath)
     }
-  }, [basePath, onCommitInfoChange]);
+  }, [basePath, onCommitInfoChange])
 
   useEffect(() => {
     if (apiRef.current && basePath && treeAllData.length > 0) {
@@ -202,16 +223,15 @@ const handleNodeToggle = useCallback((_event: React.SyntheticEvent | null, nodeI
     }
   }, [basePath, treeAllData, apiRef])
 
-  const showInitialSkeleton = (isTreeLoading || loadingDirectories.has(basePath)) && treeAllData?.length === 0;
+  const showInitialSkeleton = (isTreeLoading || loadingDirectories.has(basePath)) && treeAllData?.length === 0
 
   return (
     <>
       {showInitialSkeleton ? (
         <Box sx={{ display: 'flex', paddingLeft: '16px' }}>
-          <Skeleton width="200px" height="30px" />
+          <Skeleton width='200px' height='30px' />
         </Box>
-      ) 
-      : (
+      ) : (
         <RichTreeView
           apiRef={apiRef}
           items={treeAllData}
@@ -220,17 +240,12 @@ const handleNodeToggle = useCallback((_event: React.SyntheticEvent | null, nodeI
           onExpandedItemsChange={handleNodeToggle}
           sx={{ height: 'fit-content', flexGrow: 1, width: '100%', overflow: 'auto' }}
           slots={{
-            item: (itemProps) => (
-              <CustomTreeItem 
-                {...itemProps}
-                loadingDirectories={loadingDirectories}
-              />
-            )
+            item: (itemProps) => <CustomTreeItem {...itemProps} loadingDirectories={loadingDirectories} />
           }}
         />
       )}
     </>
-  );
-};
+  )
+}
 
-export default RepoTree;
+export default RepoTree

--- a/moon/apps/web/hooks/useRefsFromRouter.ts
+++ b/moon/apps/web/hooks/useRefsFromRouter.ts
@@ -1,26 +1,28 @@
+import { useCallback } from 'react'
 import { useRouter } from 'next/router'
-import { useCallback, useMemo } from 'react'
 
+// The file can be deleted.
 export function useRefsFromRouter() {
   const router = useRouter()
-  const refs = useMemo(() => {
-    const r = router.query.refs
-
-    if (!r) return undefined
-    return Array.isArray(r) ? r[0] : r
-  }, [router.query.refs])
+  const refs = router.query.version as string
 
   const setRefs = useCallback(
     (newRefs?: string) => {
-      const { pathname, query } = router
-      const nextQuery: Record<string, any> = { ...query }
-      
-      if (!newRefs) {
-        delete nextQuery.refs
-      } else {
-        nextQuery.refs = newRefs
+      const { query } = router
+      const org = query.org
+
+      let pathArray: string[] = []
+
+      if (query.path) {
+        pathArray = Array.isArray(query.path) ? query.path : [query.path]
       }
-      router.push({ pathname, query: nextQuery }, undefined, { shallow: false })
+      const currentPath = pathArray.join('/')
+
+      if (!newRefs) {
+        router.push(`/${org}/code/tree/main/${currentPath}`)
+      } else {
+        router.push(`/${org}/code/tree/${encodeURIComponent(newRefs)}/${currentPath}`)
+      }
     },
     [router]
   )

--- a/moon/apps/web/pages/[org]/code/blob/[version]/[...path]/index.tsx
+++ b/moon/apps/web/pages/[org]/code/blob/[version]/[...path]/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { useRouter } from 'next/router'
+import { Theme } from '@radix-ui/themes'
+import { useParams } from 'next/navigation'
 
 import CodeContent from '@/components/CodeView/BlobView/CodeContent'
 import CommitHistory, { CommitInfo } from '@/components/CodeView/CommitHistory'
@@ -8,8 +9,6 @@ import RepoTree from '@/components/CodeView/TreeView/RepoTree'
 import { AppLayout } from '@/components/Layout/AppLayout'
 import AuthAppProviders from '@/components/Providers/AuthAppProviders'
 import { useGetBlob } from '@/hooks/useGetBlob'
-import { useRefsFromRouter } from '@/hooks/useRefsFromRouter'
-import { Theme } from '@radix-ui/themes'
 
 const codeStyle = {
   borderRadius: 8,
@@ -32,9 +31,12 @@ const treeStyle = {
 }
 
 function BlobPage() {
-  const { path = [] } = useRouter().query as { path?: string[] }
+  const params = useParams()
+  const { version, path = [] } = params as { version: string; path?: string[] }
+
+  const refs = version === 'main' ? undefined : version
   const new_path = '/' + path.join('/')
-  const { refs } = useRefsFromRouter()
+
   const { data: blobData, isLoading: isCodeLoading } = useGetBlob({ path: new_path, refs })
   const fileContent = blobData?.data ?? ''
   const commitInfo: CommitInfo = {
@@ -50,20 +52,20 @@ function BlobPage() {
   return (
     <Theme>
       <div className='relative m-4 h-screen'>
-          <BreadCrumb path={path} />
-          {/* tree */}
-          <div className='flex gap-4'>
-            <div style={treeStyle}>
-              <RepoTree />
-            </div>
-
-            <div style={codeStyle}>
-              <div>
-                <CommitHistory flag={'details'} info={commitInfo} />
-              </div>
-              <CodeContent fileContent={fileContent} path={path} isCodeLoading={isCodeLoading} />
-            </div>
+        <BreadCrumb path={path} />
+        {/* tree */}
+        <div className='flex gap-4'>
+          <div style={treeStyle}>
+            <RepoTree />
           </div>
+
+          <div style={codeStyle}>
+            <div>
+              <CommitHistory flag={'details'} info={commitInfo} />
+            </div>
+            <CodeContent fileContent={fileContent} path={path} isCodeLoading={isCodeLoading} />
+          </div>
+        </div>
       </div>
     </Theme>
   )

--- a/moon/apps/web/pages/[org]/code/tree/[version]/[...path]/index.tsx
+++ b/moon/apps/web/pages/[org]/code/tree/[version]/[...path]/index.tsx
@@ -21,15 +21,15 @@ import AuthAppProviders from '@/components/Providers/AuthAppProviders'
 import { useGetBlob } from '@/hooks/useGetBlob'
 import { useGetTreeCommitInfo } from '@/hooks/useGetTreeCommitInfo'
 import { useGetTreePathCanClone } from '@/hooks/useGetTreePathCanClone'
-import { useRefsFromRouter } from '@/hooks/useRefsFromRouter'
 
 function TreeDetailPage() {
   const params = useParams()
-  const { path = [] } = params as { path?: string[] }
+  const { version, path = [] } = params as { version: string; path?: string[] }
+
+  const refs = version === 'main' ? undefined : version
   const new_path = '/' + path?.join('/')
 
   const [newPath, setNewPath] = useState(new_path)
-  const { refs } = useRefsFromRouter()
   const { data: TreeCommitInfo } = useGetTreeCommitInfo(newPath, refs)
 
   type DirectoryType = NonNullable<CommonResultVecTreeCommitItem['data']>
@@ -89,7 +89,7 @@ function TreeDetailPage() {
           {!isNewCode ? (
             <>
               <div className='m-1 flex justify-end gap-2'>
-                {refs && <TagSwitcher />}
+                <TagSwitcher />
                 <Button onClick={() => handleNewClick('file')}>New File</Button>
                 <Button onClick={() => handleNewClick('folder')}>New Folder</Button>
                 {canClone?.data && <CloneTabs />}
@@ -118,7 +118,12 @@ function TreeDetailPage() {
             </div>
           ) : (
             <div className='pb-18 flex-1 overflow-hidden'>
-              <NewCodeView currentPath={new_path} onClose={handleCloseClick} defaultType={newEntryType} />
+              <NewCodeView
+                currentPath={new_path}
+                onClose={handleCloseClick}
+                defaultType={newEntryType}
+                version={version}
+              />
             </div>
           )}
         </div>


### PR DESCRIPTION
- Components now uniformly read the version from router.query.version
- Routes changed to: /tree/[version]/[...path] and /blob/[version]/[...path]
- URL example: /mega/code/tree/1.0.0/doc (formerly /tree/doc?refs=1.0.0)
- Fixed user display error on the Tag page