### PR TITLE
feat(mono): refactor directory update sync with refs(#1569)

### DIFF
--- a/orion-server/docker-compose.yml
+++ b/orion-server/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   app:
@@ -15,8 +15,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      db-init:
-        condition: service_completed_successfully
     restart: unless-stopped
 
   db:
@@ -36,35 +34,6 @@ services:
       timeout: 5s
       retries: 5
     restart: unless-stopped
-
-  db-init:
-    image: postgres:15
-    container_name: orion-db-init
-    depends_on:
-      db:
-        condition: service_healthy
-    environment:
-      PGPASSWORD: postgres
-    volumes:
-      - ./db/schema.sql:/schema.sql:ro
-    entrypoint: ["sh", "-lc"]
-    command: |
-      set -euo pipefail
-      echo "[db-init] Waiting for Postgres to be ready..."
-      until pg_isready -h db -p 5432 -U postgres >/dev/null 2>&1; do echo -n "."; sleep 1; done
-      echo " OK"
-
-      if ! psql -h db -p 5432 -U postgres -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='orion'" | grep -q 1; then
-        echo "[db-init] Creating database 'orion'..."
-        psql -h db -p 5432 -U postgres -d postgres -v ON_ERROR_STOP=1 -c "CREATE DATABASE orion"
-      else
-        echo "[db-init] Database 'orion' already exists."
-      fi
-
-      echo "[db-init] Applying schema to 'orion'..."
-      psql -h db -p 5432 -U postgres -d orion -v ON_ERROR_STOP=1 -f /schema.sql
-      echo "[db-init] Schema applied."
-    restart: "no"
 
 volumes:
   pgdata:


### PR DESCRIPTION
## 变更类型
功能优化 / 重构

## 变更内容
1. 修复目录级 clone 缓存的 refs 不同步问题：
   - 新文件创建、删除或修改时，自动刷新对应 refs 缓存；
   - 新目录创建或删除，以及目录下文件更新时，触发递归刷新缓存。
2. 重构核心函数：
   - `build_result_by_chain` 和 `apply_update_result` 优化；
   - 合并数据库操作，支持批量更新；
   - 明确 Ref 更新逻辑，并行更新非依赖目录；
   - 避免重复计算 commit/tree；
   - 优化 `TreeUpdateResult` 结果结构。
3. 保证 commit / push 和 API 文件修改触发的缓存更新行为一致。

## 当前refs变更逻辑
1. 创建文件/目录的时候,如果数据库中已经有对应的refs,同步更新.
2. cl merge的时候,不会删除更新目录的ref,而是直接更新ref到最新的.(但是会删除掉子目录的refs,因为无法获得对应的hash来进行更新)
3. 修复 refs 更新逻辑：现在只更新实际受影响的 refs. CL 合并时，仅更新对应 CL 的 ref；直接创建文件或目录时，仅更新 name 为refs/heads/main的refs，避免不必要的全量更新.


## 影响范围
- 新建目录/文件；
- cl merge 逻辑;

## 关联任务
- #1569 