### PR TITLE
feat(scorpio): add support for multi-task builds

### DIFF
--- a/orion/src/buck_controller.rs
+++ b/orion/src/buck_controller.rs
@@ -7,10 +7,12 @@ use std::process::{ExitStatus, Stdio};
 use tokio::io::AsyncBufReadExt;
 use tokio::process::Command;
 use tokio::sync::mpsc::UnboundedSender;
-use tokio::time::{Duration, sleep};
+use tokio::time::Duration;
 
 static PROJECT_ROOT: Lazy<String> =
     Lazy::new(|| std::env::var("BUCK_PROJECT_ROOT").expect("BUCK_PROJECT_ROOT must be set"));
+
+const MOUNT_TIMEOUT_SECS: u64 = 7200;
 
 /// Mounts filesystem via remote API for repository access.
 ///
@@ -25,9 +27,14 @@ static PROJECT_ROOT: Lazy<String> =
 /// * `Ok(true)` - Mount operation completed successfully
 /// * `Err(_)` - Mount request failed or timed out
 pub async fn mount_fs(repo: &str, cl: &str) -> Result<bool, Box<dyn Error + Send + Sync>> {
-    let client = reqwest::Client::new();
-    let mount_payload = json!({ "path": repo, "cl": cl });
+    // Mount operations may trigger remote repo fetching, dependency downloads,
+    // or other network-heavy steps. To avoid premature timeouts when the network
+    // is slow, we use a generous 2-hour timeout here. This can be tuned later.
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(MOUNT_TIMEOUT_SECS))
+        .build()?;
 
+    let mount_payload = json!({ "path": repo, "cl": cl });
     let mount_res = client
         .post("http://localhost:2725/api/fs/mount")
         .header("Content-Type", "application/json")
@@ -35,14 +42,41 @@ pub async fn mount_fs(repo: &str, cl: &str) -> Result<bool, Box<dyn Error + Send
         .send()
         .await?;
 
-    let mount_body: Value = mount_res.json().await?;
+    let mut mount_body: Value = mount_res.json().await?;
 
     if mount_body.get("status").and_then(|v| v.as_str()) != Some("Success") {
         let err_msg = mount_body
             .get("message")
             .and_then(|v| v.as_str())
             .unwrap_or("Mount request failed");
-        return Err(err_msg.into());
+        if err_msg == "please unmount" {
+            // Unmount first
+            unmount_fs(repo, cl).await?;
+
+            // Then retry the mount operation once
+            let retry_mount_res = client
+                .post("http://localhost:2725/api/fs/mount")
+                .header("Content-Type", "application/json")
+                .body(mount_payload.to_string())
+                .send()
+                .await?;
+
+            let retry_mount_body: Value = retry_mount_res.json().await?;
+
+            // Check if retry was successful
+            if retry_mount_body.get("status").and_then(|v| v.as_str()) != Some("Success") {
+                let retry_err_msg = retry_mount_body
+                    .get("message")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Mount request failed after unmount");
+                return Err(retry_err_msg.into());
+            }
+
+            // If retry was successful, continue with the new response
+            mount_body = retry_mount_body;
+        } else {
+            return Err(err_msg.into());
+        }
     }
 
     let request_id = mount_body
@@ -53,63 +87,64 @@ pub async fn mount_fs(repo: &str, cl: &str) -> Result<bool, Box<dyn Error + Send
 
     tracing::debug!("Mount request initiated with request_id: {}", request_id);
 
-    let max_attempts: u64 = std::env::var("SELECT_TASK_COUNT")
-        .unwrap_or_else(|_| "30".to_string())
-        .parse()
-        .unwrap_or(30);
+    // Check task status
+    let select_url = format!("http://localhost:2725/api/fs/select/{request_id}");
+    let select_res = client.get(&select_url).send().await?;
+    let select_body: Value = select_res.json().await?;
 
-    let initial_poll_interval_secs: u64 = std::env::var("INITIAL_POLL_INTERVAL_SECS")
-        .unwrap_or_else(|_| "10".to_string())
-        .parse()
-        .unwrap_or(10);
+    tracing::debug!("Polling mount status : {:?}", select_body);
 
-    let max_poll_interval_secs = 120; // Maximum backoff interval: 2 minutes
-
-    let mut poll_interval = initial_poll_interval_secs;
-
-    for attempt in 1..=max_attempts {
-        sleep(Duration::from_secs(poll_interval)).await;
-        poll_interval = std::cmp::min(poll_interval * 2, max_poll_interval_secs);
-
-        let select_url = format!("http://localhost:2725/api/fs/select/{request_id}");
-        let select_res = client.get(&select_url).send().await?;
-        let select_body: Value = select_res.json().await?;
-
-        tracing::debug!(
-            "Polling mount status (attempt {}/{}): {:?}",
-            attempt,
-            max_attempts,
-            select_body
-        );
-
-        if select_body.get("status").and_then(|v| v.as_str()) != Some("Success") {
-            let err_msg = select_body
-                .get("message")
-                .and_then(|v| v.as_str())
-                .unwrap_or("Select request failed");
-            return Err(err_msg.into());
-        }
-
-        match select_body.get("task_status").and_then(|v| v.as_str()) {
-            Some("finished") => {
-                tracing::info!(
-                    "Mount task completed successfully for request_id: {}",
-                    request_id
-                );
-                return Ok(true);
-            }
-            Some("error") => {
-                let message = select_body
-                    .get("message")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("Unknown error");
-                return Err(format!("Mount task failed: {message}").into());
-            }
-            _ => continue,
-        }
+    if select_body.get("status").and_then(|v| v.as_str()) != Some("Success") {
+        let err_msg = select_body
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Select request failed");
+        return Err(err_msg.into());
     }
 
-    Err("Mount operation timed out".into())
+    match select_body.get("task_status").and_then(|v| v.as_str()) {
+        Some("finished") => {
+            tracing::info!(
+                "Mount task completed successfully for request_id: {}",
+                request_id
+            );
+            Ok(true)
+        }
+        Some("error") => {
+            let message = select_body
+                .get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Unknown error");
+            Err(format!("Mount task failed: {message}").into())
+        }
+        _ => unmount_fs(repo, cl).await,
+    }
+}
+
+async fn unmount_fs(repo: &str, cl: &str) -> Result<bool, Box<dyn Error + Send + Sync>> {
+    let client = reqwest::Client::new();
+    let unmount_payload = serde_json::json!({
+        "path": format!("{}_{}", repo.trim_start_matches('/'), cl)
+    });
+
+    let unmount_res = client
+        .post("http://localhost:2725/api/fs/unmount")
+        .header("Content-Type", "application/json")
+        .body(unmount_payload.to_string())
+        .send()
+        .await?;
+
+    let unmount_body: serde_json::Value = unmount_res.json().await?;
+
+    if unmount_body.get("status").and_then(|v| v.as_str()) != Some("Success") {
+        let err_msg = unmount_body
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Unmount request failed");
+        return Err(err_msg.into());
+    }
+
+    Ok(true)
 }
 
 /// Executes buck build with filesystem mounting and output streaming.
@@ -152,7 +187,7 @@ pub async fn build(
     let cmd = cmd
         .arg("build")
         .arg(&target)
-        .current_dir(format!("{}/{}", *PROJECT_ROOT, repo))
+        .current_dir(format!("{}{}_{}", *PROJECT_ROOT, repo, cl))
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
@@ -205,5 +240,11 @@ pub async fn build(
     }
 
     let status = child.wait().await?;
+
+    // Clean up the mount dir
+    match unmount_fs(&repo, &cl).await {
+        Ok(_) => tracing::info!("[Task {}] Filesystem unmounted successfully.", id),
+        Err(e) => tracing::error!("[Task {}] Failed to unmount filesystem: {}", id, e),
+    }
     Ok(status)
 }

--- a/scorpio/README.md
+++ b/scorpio/README.md
@@ -64,7 +64,7 @@ The following interfaces are currently available:
 ```bash
 curl -X POST http://localhost:2725/api/fs/mount      -H "Content-Type: application/json"      -d '{"path": "third-party/mega/scorpio"}'
 curl -X GET http://localhost:2725/api/fs/mpoint
-curl -X POST http://localhost:2725/api/fs/umount      -H "Content-Type: application/json"      -d '{"path": "third-party/mega/scorpio"}'
+curl -X POST http://localhost:2725/api/fs/unmount      -H "Content-Type: application/json"      -d '{"path": "third-party/mega/scorpio"}'
 curl -X POST http://localhost:2725/api/fs/mount      -H "Content-Type: application/json"      -d '{"path": "third-party/mega/ts"}'
 ```
 

--- a/scorpio/doc/api.md
+++ b/scorpio/doc/api.md
@@ -55,7 +55,7 @@ This server provides endpoints to manage file system mounting and configuration 
 ```
 
 ### 3. **Unmount Directory**
-**URL**: `/api/fs/umount`  
+**URL**: `/api/fs/unmount`  
 **Method**: POST  
 **Description**: Unmounts a directory using its path or inode.
 

--- a/scorpio/src/dicfuse/store.rs
+++ b/scorpio/src/dicfuse/store.rs
@@ -382,6 +382,7 @@ pub struct DirItem {
     hash: String,
     file_list: HashMap<String, bool>,
 }
+
 pub struct DictionaryStore {
     inodes: Arc<Mutex<HashMap<u64, Arc<DicItem>>>>,
     // dirs: Arc<Mutex<HashMap<String, DirItem>>>, //save all the dirs.

--- a/scorpio/src/dicfuse/tree_store.rs
+++ b/scorpio/src/dicfuse/tree_store.rs
@@ -15,7 +15,7 @@ pub struct TreeStorage {
     db: Db,
 }
 
-#[derive(Serialize, Deserialize, Clone, Encode, Decode)]
+#[derive(Serialize, Deserialize, Clone, Encode, Decode, Debug)]
 pub struct StorageItem {
     inode: u64,
     parent: u64,

--- a/scorpio/src/manager/mod.rs
+++ b/scorpio/src/manager/mod.rs
@@ -178,12 +178,21 @@ impl ScorpioManager {
 
     pub fn check_before_mount(&self, mono_path: &str) -> Result<(), String> {
         for work in &self.works {
-            if work.path.starts_with(mono_path) || mono_path.starts_with(&work.path) {
+            // check if work.path and mono_path are equal or parent/child
+            if work.path == mono_path
+                || (work.path.starts_with(mono_path)
+                    && work.path.len() > mono_path.len()
+                    && work.path.as_bytes()[mono_path.len()] == b'/')
+                || (mono_path.starts_with(&work.path)
+                    && mono_path.len() > work.path.len()
+                    && mono_path.as_bytes()[work.path.len()] == b'/')
+            {
                 return Err(work.path.clone());
             }
         }
         Ok(())
     }
+
     /// Iterate through the manager's works to find the specified path's workspace and remove it.
     pub async fn remove_workspace(
         &mut self,


### PR DESCRIPTION
# 方案描述：Scorpio 支持多任务构建

## 背景
原需求是让 Orion 管理多个 Scorpio 挂载，以便在多个 Buck2 构建任务，任务之间互不影响，并在构建完成后及时清理 Scorpio 文件系统。  

然而这种方案会对 Orion 模块产生较大改动，同时可能导致资源冗余（每个挂载独立的 store 会占用额外存储）。

## 方案
改为由 **Scorpio 自身支持多任务构建**，具体做法如下：

1. **挂载目录管理**
   - Scorpio 挂载目录末尾增加 `cl_link`，例如 `/project/hello_buck2_TESTDVEE`，用于绑定具体任务。
   - OverlayFS 结构调整为：
     ```text
     lower
     upper
     cl/{cl_link}
     ```

2. **挂载与卸载流程**
   - `mount_handler` 支持同步等待挂载，并返回错误信息。
   - 处理重复挂载的场景：如果同一个 CL 正在挂载中，新任务会先调用 `unmount` 再重新挂载。
   - 构建任务完成后，无论成功与否，都执行 `unmount` 清理对应 CL 层缓存。

3. **任务隔离**
   - 不同构建任务对应不同 CL 层（`cl/{cl_link}`），任务之间互不干扰。
   - CL 层文件不会覆盖下层，保证任务独立性。

## 优点
- 对 Orion 模块改动最小，原有功能不受影响。
- 节省存储资源，共享 lower/upper 层缓存。
- 支持重复任务构建，任务之间完全隔离。
- 挂载和卸载流程更稳定，可处理重复挂载和异常清理情况。

# 具体改动内容

## 新增功能
- 挂载目录命名逻辑调整，末尾增加 `cl_link`，用于绑定具体 CL。
- OverlayFS 结构调整：
  ```text
  lower
  upper
  cl/{cl_link}
  ```
## 功能改动

- `mount_handler` 改为同步等待挂载，并可返回错误信息。
- `mount_handler` 负责处理重复挂载等异常场景。
- `mount_fs` 改为同步等待 `mount_handler`，最长等待 2 小时，超时取消挂载。
- `mount_fs` 遇到重复挂载时，会先调用 `unmount` 再重新挂载，解决上一个 CL task 尚未完成的问题。
- `orion` 新增 `unmount` 方法。
- 构建结束后，无论成功与否，都执行 `unmount`，确保及时清理。
- `unmount` 更新逻辑：会清理 `cl/{cl_link}` 下的代码，因缓存有效期短且数据量小。

## Bug 修复

- 修复 CL 层代码未创建的问题。
- OverlayFS CL 层文件不会覆盖下层文件。

## 关联 Issue

- 关联 #1566
