### PR TITLE
feat: show per-file last-modified commit when browsing via tag

### DIFF
--- a/ceres/src/api_service/history.rs
+++ b/ceres/src/api_service/history.rs
@@ -259,7 +259,7 @@ pub async fn item_to_commit_map_with_refs<T: ApiHandler + ?Sized>(
 
     // Resolve commit from refs (SHA or tag)
     let is_hex_sha1 = |s: &str| s.len() == 40 && s.chars().all(|c| c.is_ascii_hexdigit());
-    let mut commit_hash = String::new();
+    let commit_hash;
 
     if is_hex_sha1(maybe) {
         // Direct commit SHA

--- a/ceres/src/api_service/tree_ops.rs
+++ b/ceres/src/api_service/tree_ops.rs
@@ -14,7 +14,7 @@ use git_internal::{
 };
 use jupiter::utils::converter::generate_git_keep_with_timestamp;
 
-use crate::api_service::{ApiHandler, history::item_to_commit_map_with_refs};
+use crate::api_service::{ApiHandler, history::item_to_commit_map};
 use crate::model::git::{TreeBriefItem, TreeCommitItem, TreeHashItem};
 
 pub async fn get_tree_commit_info<T: ApiHandler + ?Sized>(
@@ -24,7 +24,7 @@ pub async fn get_tree_commit_info<T: ApiHandler + ?Sized>(
 ) -> Result<Vec<TreeCommitItem>, GitError> {
     // Use refs-aware commit mapping to get individual commit info for each file/directory
     // This ensures each item shows its own last modification commit, not just the tag commit
-    let commit_map = item_to_commit_map_with_refs(handler, path, refs).await?;
+    let commit_map = item_to_commit_map(handler, path, refs).await?;
     let mut items: Vec<TreeCommitItem> = commit_map.into_iter().map(TreeCommitItem::from).collect();
     items.sort_by(|a, b| {
         a.content_type

--- a/ceres/src/api_service/tree_ops.rs
+++ b/ceres/src/api_service/tree_ops.rs
@@ -14,7 +14,7 @@ use git_internal::{
 };
 use jupiter::utils::converter::generate_git_keep_with_timestamp;
 
-use crate::api_service::{ApiHandler, history::item_to_commit_map};
+use crate::api_service::{ApiHandler, history::item_to_commit_map_with_refs};
 use crate::model::git::{TreeBriefItem, TreeCommitItem, TreeHashItem};
 
 pub async fn get_tree_commit_info<T: ApiHandler + ?Sized>(
@@ -22,47 +22,9 @@ pub async fn get_tree_commit_info<T: ApiHandler + ?Sized>(
     path: PathBuf,
     refs: Option<&str>,
 ) -> Result<Vec<TreeCommitItem>, GitError> {
-    // If refs provided, resolve to commit and list items from that commit's tree at path,
-    // attaching the same commit info to each item for consistent, minimal behavior.
-    let maybe = refs.unwrap_or("").trim();
-    if !maybe.is_empty() {
-        // Resolve commit from refs (SHA or tag)
-        let is_hex_sha1 = |s: &str| s.len() == 40 && s.chars().all(|c| c.is_ascii_hexdigit());
-        let mut commit_hash = String::new();
-        if is_hex_sha1(maybe) {
-            commit_hash = maybe.to_string();
-        } else if let Ok(Some(tag)) = handler.get_tag(None, maybe.to_string()).await {
-            commit_hash = tag.object_id;
-        }
-
-        if !commit_hash.is_empty() {
-            let commit = handler.get_commit_by_hash(&commit_hash).await;
-            // Use refs-aware tree search
-            if let Some(tree) = search_tree_by_path(handler, &path, refs).await? {
-                let mut items: Vec<TreeCommitItem> = tree
-                    .tree_items
-                    .into_iter()
-                    .map(|item| TreeCommitItem::from((item, Some(commit.clone()))))
-                    .collect();
-                items.sort_by(|a, b| {
-                    a.content_type
-                        .cmp(&b.content_type)
-                        .then(a.name.cmp(&b.name))
-                });
-                return Ok(items);
-            } else {
-                // path not found under this refs
-                return Ok(vec![]);
-            }
-        } else {
-            return Err(GitError::CustomError(
-                "Invalid refs: tag or commit not found".to_string(),
-            ));
-        }
-    }
-
-    // No refs provided: fallback to existing behavior
-    let commit_map = item_to_commit_map(handler, path).await?;
+    // Use refs-aware commit mapping to get individual commit info for each file/directory
+    // This ensures each item shows its own last modification commit, not just the tag commit
+    let commit_map = item_to_commit_map_with_refs(handler, path, refs).await?;
     let mut items: Vec<TreeCommitItem> = commit_map.into_iter().map(TreeCommitItem::from).collect();
     items.sort_by(|a, b| {
         a.content_type


### PR DESCRIPTION
## Description

This PR fixes the issue where all files displayed the same commit message and date when browsing a repository by tag. Now each file shows its actual last modification commit information.

### Related Issue
Fixes #1588

## Changes Made

### 1. New `item_to_commit_map_with_refs` function
- **Location**: `ceres/src/api_service/history.rs`
- **Purpose**: Finds the last modification commit for each file/directory starting from a ref (tag or commit SHA)
- **Supports**:
  - Direct commit SHA (40-character hex)
  - Tag names (both `refs/tags/xxx` and `xxx` formats)
  - Annotated tags and lightweight tags

### 2. New `traverse_commit_history_for_last_modification` function
- **Location**: `ceres/src/api_service/history.rs`
- **Purpose**: Traverses commit history backwards to find the last commit that modified a specific file by comparing item hashes
- **Key difference from `traverse_commit_history`**:
  - Old function: Finds the first appearance of an item
  - New function: Finds the last modification of an item (by comparing hashes)

### 3. Modified `get_tree_commit_info` function
- **Location**: `ceres/src/api_service/tree_ops.rs`
- **Change**: Uses `item_to_commit_map_with_refs` in refs mode instead of binding all items to the same commit
- **Result**: Each file/directory now displays its own last modification commit information

## Behavior Comparison

| Scenario | Before Fix | After Fix |
|----------|------------|-----------|
| Browsing by tag | All files show same message/date (tag's commit) | Each file shows its actual last modification commit info |
| Default behavior (no refs) | Unchanged | Unchanged |
