### PR TITLE
feat(ssr): introduce dedicated internal API configuration for SSR

### DIFF
--- a/moon/apps/web/.env.openatom
+++ b/moon/apps/web/.env.openatom
@@ -4,3 +4,5 @@ NEXT_PUBLIC_WEB_URL=https://app.xuanwu.openatom.cn
 NEXT_PUBLIC_SYNC_URL=wss://sync.xuanwu.openatom.cn
 NEXT_PUBLIC_AUTH_URL=https://auth.xuanwu.openatom.cn
 NEXT_PUBLIC_CRATES_PRO_URL=https://cratespro.xuanwu.openatom.cn
+
+NEXT_PUBLIC_INTERNAL_API_URL=http://campsite-api.mega-rag.svc.cluster.local

--- a/moon/apps/web/.env.staging
+++ b/moon/apps/web/.env.staging
@@ -4,3 +4,5 @@ NEXT_PUBLIC_WEB_URL=https://app.gitmega.com
 NEXT_PUBLIC_SYNC_URL=wss://sync.gitmega.com
 NEXT_PUBLIC_AUTH_URL=https://auth.gitmega.com
 NEXT_PUBLIC_CRATES_PRO_URL=http://cratespro.gitmega.nju:8080
+
+NEXT_PUBLIC_INTERNAL_API_URL=https://api.gitmega.com

--- a/moon/apps/web/.env.staging-nju
+++ b/moon/apps/web/.env.staging-nju
@@ -4,3 +4,5 @@ NEXT_PUBLIC_WEB_URL=http://app.gitmega.nju:8080
 NEXT_PUBLIC_SYNC_URL=ws://sync.gitmega.nju:8080
 NEXT_PUBLIC_AUTH_URL=http://auth.gitmega.nju:8080
 NEXT_PUBLIC_CRATES_PRO_URL=http://cratespro.gitmega.nju:8080
+
+NEXT_PUBLIC_INTERNAL_API_URL=http://api.gitmega.nju:8080

--- a/moon/apps/web/next.config.js
+++ b/moon/apps/web/next.config.js
@@ -36,6 +36,7 @@ const cspResourcesByDirective = {
     // Staging and production environments
     'wss://*.gitmega.com',
     'https://*.gitmega.com',
+    'http://*.gitmega.com',
     // Crates Pro environments
     'https://*.xuanwu.openatom.cn',
     'wss://*.xuanwu.openatom.cn',

--- a/moon/apps/web/pages/[org]/digests/[digestId]/index.tsx
+++ b/moon/apps/web/pages/[org]/digests/[digestId]/index.tsx
@@ -5,7 +5,7 @@ import { ApiErrorTypes } from '@gitmono/types'
 import { AppLayout } from '@/components/Layout/AppLayout'
 import AuthAppProviders from '@/components/Providers/AuthAppProviders'
 import { apiCookieHeaders } from '@/utils/apiCookieHeaders'
-import { apiClient, signinUrl } from '@/utils/queryClient'
+import { signinUrl, ssrApiClient } from '@/utils/queryClient'
 import { PageWithLayout } from '@/utils/types'
 
 const DigestPage: PageWithLayout<any> = () => {
@@ -25,9 +25,11 @@ export default DigestPage
 export const getServerSideProps: GetServerSideProps = async ({ req, query }) => {
   try {
     const headers = apiCookieHeaders(req.cookies)
-    const result = await apiClient.organizations.getDigestsMigrations().request(`${query?.org}`, `${query?.digestId}`, {
-      headers
-    })
+    const result = await ssrApiClient.organizations
+      .getDigestsMigrations()
+      .request(`${query?.org}`, `${query?.digestId}`, {
+        headers
+      })
 
     if (result.note_url) {
       return {

--- a/moon/apps/web/pages/[org]/p/notes/[noteId].tsx
+++ b/moon/apps/web/pages/[org]/p/notes/[noteId].tsx
@@ -21,7 +21,7 @@ import { ScrollableContainer } from '@/components/ScrollableContainer'
 import { ScopeProvider } from '@/contexts/scope'
 import { useCreateNoteView } from '@/hooks/useCreateNoteView'
 import { QueryNormalizerProvider } from '@/utils/normy/QueryNormalizerProvider'
-import { apiClient, queryClient } from '@/utils/queryClient'
+import { queryClient, ssrApiClient } from '@/utils/queryClient'
 import { getNormalizedKey } from '@/utils/queryNormalization'
 import { PageWithLayout } from '@/utils/types'
 
@@ -188,7 +188,7 @@ export async function getStaticProps({ params }: GetStaticPropsContext) {
   }
 
   try {
-    const data = await apiClient.organizations.getNotesPublicNotes().request(org, parsedNoteId)
+    const data = await ssrApiClient.organizations.getNotesPublicNotes().request(org, parsedNoteId)
 
     return {
       props: {

--- a/moon/apps/web/pages/[org]/posts/[postId]/index.tsx
+++ b/moon/apps/web/pages/[org]/posts/[postId]/index.tsx
@@ -5,7 +5,7 @@ import { AppLayout } from '@/components/Layout/AppLayout'
 import { PostView } from '@/components/Post/PostView'
 import AuthAppProviders from '@/components/Providers/AuthAppProviders'
 import { SsrSecretHeader } from '@/utils/apiCookieHeaders'
-import { apiClient } from '@/utils/queryClient'
+import { ssrApiClient } from '@/utils/queryClient'
 import { PageWithLayout } from '@/utils/types'
 
 export interface PostRouteQuery {
@@ -50,9 +50,11 @@ PostPage.getInitialProps = async ({ asPath }: NextPageContext) => {
   }
 
   try {
-    const postSeoInfo = await apiClient.organizations.getPostsSeoInfo().request(`${params?.org}`, `${params?.postId}`, {
-      headers: SsrSecretHeader
-    })
+    const postSeoInfo = await ssrApiClient.organizations
+      .getPostsSeoInfo()
+      .request(`${params?.org}`, `${params?.postId}`, {
+        headers: SsrSecretHeader
+      })
 
     return { postSeoInfo }
   } catch {

--- a/moon/apps/web/pages/index.tsx
+++ b/moon/apps/web/pages/index.tsx
@@ -5,7 +5,7 @@ import { SCOPE_COOKIE_NAME } from '@gitmono/config'
 import { ApiErrorTypes } from '@gitmono/types'
 
 import { apiCookieHeaders } from '@/utils/apiCookieHeaders'
-import { apiClient, signinUrl } from '@/utils/queryClient'
+import { signinUrl, ssrApiClient } from '@/utils/queryClient'
 
 export default function IndexPage() {
   return <></>
@@ -16,7 +16,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, query }) => 
     const { device } = userAgentFromString(req.headers['user-agent'])
     const headers = apiCookieHeaders(req.cookies)
 
-    const organizations = await apiClient.organizationMemberships
+    const organizations = await ssrApiClient.organizationMemberships
       .getOrganizationMemberships()
       .request({ headers })
       .then((res) => res.map((m) => m.organization).filter((o) => o !== null))
@@ -50,7 +50,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, query }) => 
         }
       }
     } else {
-      await apiClient.organizations.postJoinByToken().request('mega', 's3AX1iyAx3sgGNygiM67', { headers })
+      await ssrApiClient.organizations.postJoinByToken().request('mega', 's3AX1iyAx3sgGNygiM67', { headers })
 
       if (device.type === 'mobile') {
         return {

--- a/moon/apps/web/pages/invitation/[token].tsx
+++ b/moon/apps/web/pages/invitation/[token].tsx
@@ -5,12 +5,12 @@ import { ApiErrorTypes } from '@gitmono/types/generated'
 import { FullPageError } from '@/components/Error'
 import AuthAppProviders from '@/components/Providers/AuthAppProviders'
 import { apiCookieHeaders } from '@/utils/apiCookieHeaders'
-import { apiClient, signUpUrl } from '@/utils/queryClient'
+import { signUpUrl, ssrApiClient } from '@/utils/queryClient'
 
 export const getServerSideProps: GetServerSideProps = async ({ req, query }) => {
   try {
     const headers = apiCookieHeaders(req.cookies)
-    const result = await apiClient.invitationsByToken.postInvitationsByTokenAccept().request(query.token as string, {
+    const result = await ssrApiClient.invitationsByToken.postInvitationsByTokenAccept().request(query.token as string, {
       headers
     })
 

--- a/moon/apps/web/utils/queryClient.ts
+++ b/moon/apps/web/utils/queryClient.ts
@@ -1,6 +1,6 @@
 import { InfiniteData, QueryClient, QueryKey } from '@tanstack/react-query'
 
-import { MONO_API_URL, ORION_API_URL, RAILS_API_URL, RAILS_AUTH_URL } from '@gitmono/config'
+import { MONO_API_URL, ORION_API_URL, RAILS_API_URL, RAILS_AUTH_URL, RAILS_INTERNAL_API_URL } from '@gitmono/config'
 import { Api, ApiError, DataTag } from '@gitmono/types'
 
 import { ApiErrorResponse } from './types'
@@ -139,6 +139,15 @@ export const queryClient = () =>
 
 export const apiClient = new Api({
   baseUrl: RAILS_API_URL,
+  baseApiParams: {
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    format: 'json'
+  }
+})
+
+export const ssrApiClient = new Api({
+  baseUrl: RAILS_INTERNAL_API_URL,
   baseApiParams: {
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },

--- a/moon/packages/config/src/index.ts
+++ b/moon/packages/config/src/index.ts
@@ -22,6 +22,8 @@ export const LAST_CLIENT_JS_BUILD_ID_LS_KEY = 'latest-js-time'
 export const RAILS_API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://api.gitmega.com'
 
 // eslint-disable-next-line turbo/no-undeclared-env-vars
+export const RAILS_INTERNAL_API_URL = process.env.NEXT_PUBLIC_INTERNAL_API_URL || 'https://api.gitmega.com'
+// eslint-disable-next-line turbo/no-undeclared-env-vars
 export const MONO_API_URL = process.env.NEXT_PUBLIC_MONO_API_URL || 'https://git.gitmega.com'
 
 // eslint-disable-next-line turbo/no-undeclared-env-vars


### PR DESCRIPTION
- Added `NEXT_PUBLIC_INTERNAL_API_URL` to environment files for specifying the internal API domain used by SSR.
- Added `ssrApiClient` in `queryClient.ts` for server-side data fetching.
- Updated SSR pages (digests, invitation, notes, posts, etc.) to use `ssrApiClient` instead of `apiClient`.
- Client-side and local development requests continue using the public API domain.