### PR TITLE
feat: add Draft status support for conversation list

### DIFF
--- a/ceres/src/model/conversation.rs
+++ b/ceres/src/model/conversation.rs
@@ -99,6 +99,7 @@ pub enum ConvType {
     Label,
     Assignee,
     Mention,
+    Draft,
 }
 
 impl From<ConvTypeEnum> for ConvType {
@@ -118,6 +119,7 @@ impl From<ConvTypeEnum> for ConvType {
             ConvTypeEnum::Label => ConvType::Label,
             ConvTypeEnum::Assignee => ConvType::Assignee,
             ConvTypeEnum::Mention => ConvType::Mention,
+            ConvTypeEnum::Draft => ConvType::Draft,
         }
     }
 }

--- a/jupiter/callisto/src/sea_orm_active_enums.rs
+++ b/jupiter/callisto/src/sea_orm_active_enums.rs
@@ -52,6 +52,8 @@ pub enum ConvTypeEnum {
     Assignee,
     #[sea_orm(string_value = "mention")]
     Mention,
+    #[sea_orm(string_value = "draft")]
+    Draft,
 }
 #[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "merge_status_enum")]

--- a/jupiter/src/migration/m20251125_135032_add_draft_conv_type.rs
+++ b/jupiter/src/migration/m20251125_135032_add_draft_conv_type.rs
@@ -1,0 +1,31 @@
+use sea_orm_migration::{prelude::*, sea_orm::DatabaseBackend};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let backend = manager.get_database_backend();
+
+        match backend {
+            DatabaseBackend::Postgres => {
+                manager
+                    .get_connection()
+                    .execute_unprepared(
+                        r#"ALTER TYPE conv_type_enum ADD VALUE IF NOT EXISTS 'draft';"#,
+                    )
+                    .await?;
+            }
+            DatabaseBackend::Sqlite | DatabaseBackend::MySql => {}
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _: &SchemaManager) -> Result<(), DbErr> {
+        // Note: PostgreSQL does not support removing enum values directly
+        // This migration cannot be fully reversed without recreating the enum
+        Ok(())
+    }
+}

--- a/jupiter/src/migration/mod.rs
+++ b/jupiter/src/migration/mod.rs
@@ -70,6 +70,7 @@ mod m20251109_073000_add_merge_queue;
 mod m20251117_101804_add_commit_id_in_mega_tree;
 mod m20251117_181240_add_system_required_field_for_reviewer;
 mod m20251119_145041_add_draft_status;
+mod m20251125_135032_add_draft_conv_type;
 
 /// Creates a primary key column definition with big integer type.
 ///
@@ -128,6 +129,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20251117_101804_add_commit_id_in_mega_tree::Migration),
             Box::new(m20251117_181240_add_system_required_field_for_reviewer::Migration),
             Box::new(m20251119_145041_add_draft_status::Migration),
+            Box::new(m20251125_135032_add_draft_conv_type::Migration),
         ]
     }
 }

--- a/mono/src/api/guard/cedar_guard.rs
+++ b/mono/src/api/guard/cedar_guard.rs
@@ -36,7 +36,8 @@ pub static CL_ROUTER_ACTIONS: Lazy<HashMap<&'static str, ActionEnum>> = Lazy::ne
         ("reviewers", ActionEnum::EditMergeRequest),
         ("approve", ActionEnum::ApproveMergeRequest),
         ("resolve", ActionEnum::EditMergeRequest),
-        ("status", ActionEnum::EditMergeRequest),
+        // Changing status (e.g., marking as ready for review) is a distinct permission.
+        ("status", ActionEnum::RequestReview),
     ])
 });
 

--- a/mono/src/api/guard/cedar_guard.rs
+++ b/mono/src/api/guard/cedar_guard.rs
@@ -36,8 +36,7 @@ pub static CL_ROUTER_ACTIONS: Lazy<HashMap<&'static str, ActionEnum>> = Lazy::ne
         ("reviewers", ActionEnum::EditMergeRequest),
         ("approve", ActionEnum::ApproveMergeRequest),
         ("resolve", ActionEnum::EditMergeRequest),
-        // Changing status (e.g., marking as ready for review) is a distinct permission.
-        ("status", ActionEnum::RequestReview),
+        ("status", ActionEnum::EditMergeRequest),
     ])
 });
 

--- a/mono/src/api/guard/cedar_guard.rs
+++ b/mono/src/api/guard/cedar_guard.rs
@@ -36,6 +36,7 @@ pub static CL_ROUTER_ACTIONS: Lazy<HashMap<&'static str, ActionEnum>> = Lazy::ne
         ("reviewers", ActionEnum::EditMergeRequest),
         ("approve", ActionEnum::ApproveMergeRequest),
         ("resolve", ActionEnum::EditMergeRequest),
+        ("status", ActionEnum::EditMergeRequest),
     ])
 });
 

--- a/mono/src/api/router/cl_router.rs
+++ b/mono/src/api/router/cl_router.rs
@@ -716,7 +716,7 @@ async fn update_cl_status(
                     &link,
                     &user.username,
                     Some(format!("{} marked this as ready for review", user.username)),
-                    ConvTypeEnum::Edit,
+                    ConvTypeEnum::Review,
                 )
                 .await?;
         }
@@ -728,7 +728,7 @@ async fn update_cl_status(
                     &link,
                     &user.username,
                     Some(format!("{} marked this as draft", user.username)),
-                    ConvTypeEnum::Edit,
+                    ConvTypeEnum::Draft,
                 )
                 .await?;
         }


### PR DESCRIPTION
## Description
This PR adds support for draft conversation type in the CL (Change List) system.

## Changes
- **Database Enum Layer**: Added `Draft` variant to `ConvTypeEnum` in `sea_orm_active_enums.rs`
- **Database Migration**: Created new migration `m20251125_135032_add_draft_conv_type.rs` to add 'draft' value to PostgreSQL `conv_type_enum`
- **Model Layer**: Updated `ConvType` enum in `conversation.rs` with `Draft` variant and corresponding conversion
- **API Router Layer**: Modified `update_cl_status` function in `cl_router.rs`:
  - `Draft` → `Open` transition: Uses `ConvTypeEnum::Review` (consistent with request review)
  - `Open` → `Draft` transition: Uses `ConvTypeEnum::Draft` (new dedicated type)
- **Authorization**: Updated Cedar guard rules in `cedar_guard.rs` for draft status management

## Testing
-  Database migration applies successfully
- Enum conversions work correctly
- Status transitions (Draft ↔ Open) function as expected
- Authorization rules properly enforce draft permissions

## Related issues
fixed: #1603

Signed-off-by: Hongze Gao <15101764808@163.com>