### PR TITLE
bugfix(mono): update tree commit ID when modifying the tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ futures = "0.3.31"
 futures-util = "0.3.31"
 axum = { version = "0.8.7", features = ["macros", "json"] }
 axum-extra = "0.12.2"
-russh = "0.54.6"
+russh = "0.54.5"
 tower-http = "0.6.7"
 tower = "0.5.2"
 tower-sessions = { version = "0.14", features = ["memory-store"] }

--- a/ceres/src/api_service/mono_api_service.rs
+++ b/ceres/src/api_service/mono_api_service.rs
@@ -551,6 +551,8 @@ impl ApiHandler for MonoApiService {
                             );
                         }
                         result.insert(item, commit);
+                    } else {
+                        result.insert(item, None);
                     }
                 }
                 Ok(result)
@@ -1164,6 +1166,12 @@ impl MonoApiService {
             }
         }
 
+        if new_commit_id.is_empty() {
+            return Err(GitError::CustomError(
+                "no commit_id generated: no matching refs found for the update paths".into(),
+            ));
+        }
+
         storage
             .batch_update_by_path_concurrent(updates)
             .await
@@ -1179,7 +1187,8 @@ impl MonoApiService {
             .clone()
             .into_iter()
             .map(|save_t| {
-                let tree_model: mega_tree::Model = save_t.into_mega_model(EntryMeta::new());
+                let mut tree_model: mega_tree::Model = save_t.into_mega_model(EntryMeta::new());
+                tree_model.commit_id.clone_from(&new_commit_id);
                 tree_model.into()
             })
             .collect();


### PR DESCRIPTION
# 修复创建文件后根目录从 UI 消失的问题

## 问题描述
在创建文件或更新 tree 时，根目录在 UI 中会消失。原因是在apply_update_result方法中，修改 tree 后没有同步更新 tree 的 commit ID，导致数据库中，tree的commit id被覆盖为空，进而影响了commit-info获取数据，最终导致前端渲染时无法正确显示根目录。

## 解决方案
- 修改 tree 的逻辑，确保更新对应的 commit ID
- 保证 UI 能正确获取最新的 tree 状态
- 修复创建文件后根目录消失的问题
- 修改item_to_commit_map方法的逻辑，如果tree item存在，即使没有commit info，调用commit-info接口也会返回这个tree item

## 相关 issue
 #1672

## 如何回归到正常状态？
在消失的目录下创建文件/目录后，自动就会回到正常的数据状态。

## 影响范围
- 仅影响 mono 仓库的 tree 更新与 UI 显示逻辑
- 不影响其他功能模块
