### PR TITLE
Feat/dynamic sidebar api refactor

### DIFF
--- a/ceres/src/model/dynamic_sidebar.rs
+++ b/ceres/src/model/dynamic_sidebar.rs
@@ -44,3 +44,26 @@ pub struct UpdateSidebarPayload {
     pub visible: Option<bool>,
     pub order_index: Option<i32>,
 }
+
+#[derive(Clone, Debug, ToSchema, Serialize, Deserialize)]
+pub struct SidebarSyncPayload {
+    pub id: Option<i32>,
+    pub public_id: String,
+    pub label: String,
+    pub href: String,
+    pub visible: bool,
+    pub order_index: i32,
+}
+
+impl From<SidebarSyncPayload> for jupiter::model::sidebar_dto::SidebarSyncDto {
+    fn from(value: SidebarSyncPayload) -> Self {
+        Self {
+            id: value.id,
+            public_id: value.public_id,
+            label: value.label,
+            href: value.href,
+            visible: value.visible,
+            order_index: value.order_index,
+        }
+    }
+}

--- a/jupiter/src/model/mod.rs
+++ b/jupiter/src/model/mod.rs
@@ -3,3 +3,4 @@ pub mod common;
 pub mod conv_dto;
 pub mod issue_dto;
 pub mod merge_queue_dto;
+pub mod sidebar_dto;

--- a/jupiter/src/model/sidebar_dto.rs
+++ b/jupiter/src/model/sidebar_dto.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, Clone)]
+pub struct SidebarSyncDto {
+    pub id: Option<i32>,
+    pub public_id: String,
+    pub label: String,
+    pub href: String,
+    pub visible: bool,
+    pub order_index: i32,
+}

--- a/jupiter/src/storage/dynamic_sidebar_storage.rs
+++ b/jupiter/src/storage/dynamic_sidebar_storage.rs
@@ -1,12 +1,15 @@
 use std::ops::Deref;
 
-use crate::storage::base_storage::{BaseStorage, StorageConnector};
+use crate::{
+    model::sidebar_dto::SidebarSyncDto,
+    storage::base_storage::{BaseStorage, StorageConnector},
+};
 use callisto::dynamic_sidebar;
 use common::errors::MegaError;
 use sea_orm::{
     ActiveModelTrait,
     ActiveValue::{NotSet, Set},
-    EntityTrait, QueryOrder,
+    EntityTrait, QueryOrder, TransactionTrait,
 };
 
 #[derive(Clone)]
@@ -117,5 +120,54 @@ impl DynamicSidebarStorage {
         }
 
         Ok(model)
+    }
+
+    pub async fn sync_sidebar(
+        &self,
+        items: Vec<SidebarSyncDto>,
+    ) -> Result<Vec<dynamic_sidebar::Model>, MegaError> {
+        // Begin a transaction
+        let txn = self.get_connection().begin().await?;
+
+        let mut res_models = Vec::with_capacity(items.len());
+
+        for item in items {
+            if let Some(id) = item.id {
+                // Update existing menu item
+                if let Some(model) = dynamic_sidebar::Entity::find_by_id(id).one(&txn).await? {
+                    let mut active_model: dynamic_sidebar::ActiveModel = model.into();
+
+                    active_model.public_id = Set(item.public_id);
+                    active_model.label = Set(item.label);
+                    active_model.href = Set(item.href);
+                    active_model.visible = Set(item.visible);
+                    active_model.order_index = Set(item.order_index);
+
+                    let updated = active_model.update(&txn).await?;
+                    res_models.push(updated);
+                } else {
+                    return Err(MegaError::Other(format!(
+                        "Sidebar with id `{id}` not found"
+                    )));
+                }
+            } else {
+                // Insert new menu item
+                let active_model = dynamic_sidebar::ActiveModel {
+                    public_id: Set(item.public_id),
+                    label: Set(item.label),
+                    href: Set(item.href),
+                    visible: Set(item.visible),
+                    order_index: Set(item.order_index),
+                    ..Default::default()
+                };
+                let inserted = active_model.insert(&txn).await?;
+                res_models.push(inserted);
+            }
+        }
+
+        // Commit the transaction
+        txn.commit().await?;
+
+        Ok(res_models)
     }
 }

--- a/jupiter/src/storage/dynamic_sidebar_storage.rs
+++ b/jupiter/src/storage/dynamic_sidebar_storage.rs
@@ -153,12 +153,12 @@ impl DynamicSidebarStorage {
             } else {
                 // Insert new menu item
                 let active_model = dynamic_sidebar::ActiveModel {
+                    id: NotSet,
                     public_id: Set(item.public_id),
                     label: Set(item.label),
                     href: Set(item.href),
                     visible: Set(item.visible),
                     order_index: Set(item.order_index),
-                    ..Default::default()
                 };
                 let inserted = active_model.insert(&txn).await?;
                 res_models.push(inserted);

--- a/jupiter/src/storage/dynamic_sidebar_storage.rs
+++ b/jupiter/src/storage/dynamic_sidebar_storage.rs
@@ -126,6 +126,10 @@ impl DynamicSidebarStorage {
         &self,
         items: Vec<SidebarSyncDto>,
     ) -> Result<Vec<dynamic_sidebar::Model>, MegaError> {
+        if items.is_empty() {
+            return Ok(Vec::new());
+        }
+
         // Begin a transaction
         let txn = self.get_connection().begin().await?;
 

--- a/mono/src/api/router/dynamic_sidebar_router.rs
+++ b/mono/src/api/router/dynamic_sidebar_router.rs
@@ -115,7 +115,15 @@ async fn update_sidebar_by_id(
     responses(
         (status = 200, body = CommonResult<Vec<SidebarRes>>, content_type = "application/json")
     ),
-    tag = SIDEBAR_TAG
+    tag = SIDEBAR_TAG,
+    description = "Sync sidebar menus. \
+Each `public_id` and `order_index` must be unique across all sidebar items. \
+The operation will fail if: \
+- A new item has a `public_id` that already exists \
+- An update tries to set a `public_id` to one that's already in use by another item \
+- Multiple items in the payload have the same `order_index` \
+- An update tries to set an `order_index` that's already in use \
+The transaction will be rolled back if any of these constraints are violated."
 )]
 async fn sync_sidebar(
     state: State<MonoApiServiceState>,


### PR DESCRIPTION
动态菜单栏与前端联调后，决定添加一个 /sidebar/sync 的route
- 功能：支持批量更新和插入
1. 已有菜单 → 根据 id 更新其属性（public_id、label、href、visible、order_index）
2. 新建菜单 → 没有 id，后端进行id自增，同时插入新的菜单项
3. 保证 事务安全：整个批量操作要么全部成功，要么失败回滚
4. 返回最新的数据库模型集合，以便前端更新界面