### PR TITLE
fix: rm unused API(get_commit_detail)

### DIFF
--- a/ceres/src/api_service/mod.rs
+++ b/ceres/src/api_service/mod.rs
@@ -174,17 +174,6 @@ pub trait ApiHandler: Send + Sync {
         commit_ops::get_commit_files_changed(self, commit_sha, selector_path, pagination).await
     }
 
-    /// Build commit detail including summary and diffs for a given commit SHA.
-    /// The `path` acts as a required repository/subrepo selector for routing/cache,
-    /// and does not filter diff contents.
-    async fn build_commit_detail(
-        &self,
-        commit_sha: &str,
-        path: &std::path::Path,
-    ) -> Result<crate::model::commit::CommitDetail, GitError> {
-        commit_ops::build_commit_detail(self, commit_sha, path).await
-    }
-
     // Tag related operations shared across mono/import implementations.
     /// Create a tag in the repository context represented by `repo_path`.
     /// Returns TagInfo on success.

--- a/ceres/src/model/commit.rs
+++ b/ceres/src/model/commit.rs
@@ -38,13 +38,6 @@ pub struct CommitHistoryParams {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
-pub struct CommitDetail {
-    pub commit: CommitSummary,
-    /// Unified diff list compared with the previous commit (or merged parent in case of multiple parents)
-    pub diffs: Vec<DiffItem>,
-}
-
-#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
 pub struct CommitFilesChangedPage {
     pub commit: CommitSummary,
     pub page: CommonPage<DiffItem>,

--- a/mono/src/api/router/commit_router.rs
+++ b/mono/src/api/router/commit_router.rs
@@ -6,9 +6,7 @@ use axum::{
 };
 use ceres::model::change_list::MuiTreeNode;
 use ceres::model::commit::CommitBindingResponse;
-use ceres::model::commit::{
-    CommitDetail, CommitFilesChangedPage, CommitHistoryParams, CommitSummary,
-};
+use ceres::model::commit::{CommitFilesChangedPage, CommitHistoryParams, CommitSummary};
 use common::model::CommonResult;
 use common::model::{CommonPage, PageParams, Pagination};
 use serde::{Deserialize, Serialize};
@@ -27,7 +25,6 @@ pub fn routers() -> OpenApiRouter<MonoApiServiceState> {
         .routes(routes!(list_commit_history))
         .routes(routes!(commit_mui_tree))
         .routes(routes!(commit_files_changed))
-        .routes(routes!(commit_detail))
 }
 /// Update commit binding information
 #[utoipa::path(
@@ -156,30 +153,6 @@ async fn list_commit_history(
         items,
         total,
     }))))
-}
-
-/// Get commit detail (summary + diff merged with parents)
-#[utoipa::path(
-    get,
-    path = "/commits/{sha}/detail",
-    params(("sha" = String, Path, description = "Commit SHA"), ("path" = String, Query, description = "Repository/Subrepo selector (required)")),
-    responses(
-        (status = 200, description = "Commit detail",
-            body = CommonResult<CommitDetail>, content_type = "application/json"),
-        (status = 404, description = "Commit not found"),
-    ),
-    tag = CODE_PREVIEW
-)]
-#[axum::debug_handler]
-async fn commit_detail(
-    State(state): State<MonoApiServiceState>,
-    Path(sha): Path<String>,
-    axum::extract::Query(q): axum::extract::Query<std::collections::HashMap<String, String>>,
-) -> Result<Json<CommonResult<CommitDetail>>, ApiError> {
-    let selector = resolve_selector_path(&q)?;
-    let handler = state.api_handler(&selector).await?;
-    let detail = handler.build_commit_detail(&sha, &selector).await?;
-    Ok(Json(CommonResult::success(Some(detail))))
 }
 
 /// Get commit changed files tree (MUI format)


### PR DESCRIPTION
get_commit_detail has been replaced with get_commit_mui_tree && get_commit_changed_files
link (#1661 )