### PR TITLE
feat: implement cedar policy reviewer assignment

### DIFF
--- a/ceres/Cargo.toml
+++ b/ceres/Cargo.toml
@@ -16,6 +16,7 @@ jupiter = { workspace = true }
 callisto = { workspace = true }
 git-internal = { workspace = true }
 bellatrix = { workspace = true }
+saturn = { workspace = true }
 
 anyhow = { workspace = true }
 # Use 0.16.0 version for GPG Verification

--- a/ceres/src/pack/monorepo.rs
+++ b/ceres/src/pack/monorepo.rs
@@ -30,11 +30,12 @@ use git_internal::{
         pack::{encode::PackEncoder, entry::Entry},
     },
 };
+use jupiter::service::reviewer_service::ReviewerService;
 use jupiter::storage::Storage;
 use jupiter::utils::converter::FromMegaModel;
 
 use crate::{
-    api_service::{cache::GitObjectCache, mono_api_service::MonoApiService, tree_ops},
+    api_service::{ApiHandler, cache::GitObjectCache, mono_api_service::MonoApiService, tree_ops},
     merge_checker::CheckerRegistry,
     model::change_list::BuckFile,
     pack::RepoHandler,
@@ -667,12 +668,13 @@ impl MonoRepo {
 
     pub async fn save_or_update_cl(&self) -> Result<(), MegaError> {
         let storage = self.storage.cl_storage();
-        let path_str = self.path.to_str().unwrap();
+        let path_str = self.path.to_string_lossy();
         let username = self.username();
 
-        match storage.get_open_cl_by_path(path_str, &username).await? {
+        let is_new_cl = match storage.get_open_cl_by_path(&path_str, &username).await? {
             Some(cl) => {
                 self.update_existing_cl(cl).await?;
+                false
             }
             None => {
                 let link_guard = self.cl_link.read().await;
@@ -686,7 +688,7 @@ impl MonoRepo {
                 };
                 storage
                     .new_cl(
-                        path_str,
+                        &path_str,
                         cl_link,
                         &title,
                         &self.from_hash,
@@ -694,8 +696,199 @@ impl MonoRepo {
                         &username,
                     )
                     .await?;
+                true
             }
         };
+
+        // Cedar reviewer auto-assignment for new CL
+        if is_new_cl && let Err(e) = self.assign_system_reviewers().await {
+            tracing::warn!("[Cedar Reviewer] Failed to assign reviewers: {}", e);
+        }
+
+        // Resync reviewers when existing CL updates policy files
+        if !is_new_cl && let Err(e) = self.resync_current_cl_reviewers_if_policy_changed().await {
+            tracing::warn!("[Cedar Reviewer] Failed to resync reviewers: {}", e);
+        }
+
+        // TODO: Sync other Open CLs after policy file CL is merged.
+        //       This should be called from the `merge_cl` method when the PR is merged.
+        // if let Err(e) = self.sync_reviewers_if_policy_changed().await {
+        //     tracing::warn!("[Cedar Reviewer] Failed to sync reviewers: {}", e);
+        // }
+
+        Ok(())
+    }
+
+    /// Check if a file path is a Cedar policy file
+    fn is_policy_file(path: &str) -> bool {
+        path.ends_with(".cedar/policies.cedar") || path.ends_with(".cedar\\policies.cedar")
+    }
+
+    /// Resync reviewers for current CL when policy files are modified in the same push
+    async fn resync_current_cl_reviewers_if_policy_changed(&self) -> Result<(), MegaError> {
+        let changed_files = self.get_changed_files().await?;
+
+        if !changed_files.iter().any(|f| Self::is_policy_file(f)) {
+            return Ok(());
+        }
+
+        tracing::info!("[Cedar Reviewer] Policy file modified in CL update, resyncing reviewers");
+
+        // Get CL link and path
+        let link_guard = self.cl_link.read().await;
+        let cl_link = link_guard
+            .as_ref()
+            .ok_or_else(|| MegaError::Other("CL link not available".to_string()))?;
+        let path_str = self.path.to_string_lossy();
+
+        // Collect policies and resync
+        let policy_contents = self.collect_policy_contents(&self.path).await;
+        if policy_contents.is_empty() {
+            return Ok(());
+        }
+
+        let reviewer_service = ReviewerService::from_storage(self.storage.reviewer_storage());
+        reviewer_service
+            .sync_system_reviewers(cl_link, &path_str, &policy_contents)
+            .await?;
+
+        tracing::info!("[Cedar Reviewer] Reviewers resynced for CL {}", cl_link);
+        Ok(())
+    }
+
+    /// Sync affected Open CLs when policy file is merged (should be called from merge_cl)
+    #[allow(dead_code)]
+    async fn sync_reviewers_if_policy_changed(&self) -> Result<(), MegaError> {
+        let changed_files = self.get_changed_files().await?;
+
+        let policy_paths: Vec<&String> = changed_files
+            .iter()
+            .filter(|f| Self::is_policy_file(f))
+            .collect();
+
+        if policy_paths.is_empty() {
+            return Ok(());
+        }
+
+        tracing::info!("[Cedar Reviewer] Policy changed: {:?}", policy_paths);
+
+        let reviewer_service = ReviewerService::from_storage(self.storage.reviewer_storage());
+        for policy_path in policy_paths {
+            // Extract the directory containing the policy
+            // e.g., "service_a/.cedar/policies.cedar" -> "service_a"
+            // e.g., ".cedar/policies.cedar" -> "" (root policy, affects all CLs)
+            let policy_dir = PathBuf::from(policy_path)
+                .parent()
+                .and_then(|p| p.parent())
+                .map(|p| p.to_path_buf())
+                .unwrap_or_default();
+
+            let affected_cls = self
+                .storage
+                .cl_storage()
+                .get_open_cls_by_path_prefix(&policy_dir.to_string_lossy())
+                .await?;
+
+            if affected_cls.is_empty() {
+                continue;
+            }
+
+            tracing::info!(
+                "[Cedar Reviewer] Syncing {} affected CLs",
+                affected_cls.len()
+            );
+
+            for cl in &affected_cls {
+                let cl_path = PathBuf::from(&cl.path);
+                let policy_contents = self.collect_policy_contents(&cl_path).await;
+
+                if policy_contents.is_empty() {
+                    continue;
+                }
+
+                if let Err(e) = reviewer_service
+                    .sync_system_reviewers(&cl.link, &cl.path, &policy_contents)
+                    .await
+                {
+                    tracing::warn!("[Cedar Reviewer] Failed to sync CL {}: {}", cl.link, e);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get list of files changed in this commit
+    async fn get_changed_files(&self) -> Result<Vec<String>, MegaError> {
+        let mono_api_service: MonoApiService = self.into();
+
+        // Get file lists for both commits
+        let old_files = mono_api_service.get_commit_blobs(&self.from_hash).await?;
+        let new_files = mono_api_service.get_commit_blobs(&self.to_hash).await?;
+
+        // Compare and get changed files
+        let changed = mono_api_service.cl_files_list(old_files, new_files).await?;
+
+        // Extract file paths as strings
+        let file_paths: Vec<String> = changed
+            .iter()
+            .map(|f| f.path().to_string_lossy().to_string())
+            .collect();
+
+        Ok(file_paths)
+    }
+
+    /// Collect policy files from all ancestor directories for a given path
+    /// Returns list of (policy_path, content) tuples, ordered from root to leaf
+    async fn collect_policy_contents(&self, cl_path: &std::path::Path) -> Vec<(PathBuf, String)> {
+        let mono_api_service: MonoApiService = self.into();
+        let mut policy_contents: Vec<(PathBuf, String)> = Vec::new();
+
+        // Collect policies from all ancestor directories (leaf to root)
+        for component in cl_path.ancestors() {
+            // Skip empty paths but handle root directory
+            if component.as_os_str().is_empty() {
+                continue;
+            }
+
+            let policy_path = if component == std::path::Path::new("/") {
+                // Root directory: look for .cedar/policies.cedar
+                PathBuf::from(".cedar/policies.cedar")
+            } else {
+                component.join(".cedar/policies.cedar")
+            };
+
+            if let Ok(Some(content)) = mono_api_service
+                .get_blob_as_string(policy_path.clone(), Some(&self.to_hash))
+                .await
+            {
+                policy_contents.push((policy_path, content));
+            }
+        }
+
+        // Reverse to get root-to-leaf order (required for override semantics)
+        policy_contents.reverse();
+        policy_contents
+    }
+
+    /// Auto-assign system required reviewers based on .cedar/policies.cedar
+    async fn assign_system_reviewers(&self) -> Result<(), MegaError> {
+        let link_guard = self.cl_link.read().await;
+        let cl_link = link_guard
+            .as_ref()
+            .ok_or_else(|| MegaError::Other("CL link not available".to_string()))?;
+        let path_str = self.path.to_string_lossy();
+
+        let policy_contents = self.collect_policy_contents(&self.path).await;
+        if policy_contents.is_empty() {
+            return Ok(());
+        }
+
+        let reviewer_service = ReviewerService::from_storage(self.storage.reviewer_storage());
+        reviewer_service
+            .assign_system_reviewers(cl_link, &path_str, &policy_contents)
+            .await?;
+
         Ok(())
     }
 

--- a/jupiter/src/service/mod.rs
+++ b/jupiter/src/service/mod.rs
@@ -3,3 +3,4 @@
 pub mod cl_service;
 pub mod issue_service;
 pub mod merge_queue_service;
+pub mod reviewer_service;

--- a/jupiter/src/service/reviewer_service.rs
+++ b/jupiter/src/service/reviewer_service.rs
@@ -1,0 +1,706 @@
+//! Service for managing system required reviewers.
+//!
+//! This service handles automatic reviewer assignment based on Cedar policy files.
+
+use std::path::PathBuf;
+
+use common::errors::MegaError;
+use saturn::reviewer_parser::aggregate_reviewers;
+
+use crate::storage::{base_storage::BaseStorage, cl_reviewer_storage::ClReviewerStorage};
+
+#[derive(Clone)]
+pub struct ReviewerService {
+    pub reviewer_storage: ClReviewerStorage,
+}
+
+impl ReviewerService {
+    pub fn new(base_storage: BaseStorage) -> Self {
+        Self {
+            reviewer_storage: ClReviewerStorage { base: base_storage },
+        }
+    }
+
+    /// Create ReviewerService from ClReviewerStorage directly
+    pub fn from_storage(reviewer_storage: ClReviewerStorage) -> Self {
+        Self { reviewer_storage }
+    }
+
+    /// Assign system required reviewers from hierarchical policy files
+    ///
+    /// Traverses policy files from root to leaf, applying override semantics:
+    /// - Same path_pattern: child directory rules override parent directory rules
+    /// - Different path_patterns: rules are merged (accumulated)
+    ///
+    /// # Arguments
+    /// * `cl_link` - The CL link identifier
+    /// * `cl_path` - The path of the CL
+    /// * `policy_contents` - List of (policy_path, content) tuples, from root to leaf
+    ///
+    /// # Returns
+    /// List of assigned reviewer usernames
+    pub async fn assign_system_reviewers(
+        &self,
+        cl_link: &str,
+        cl_path: &str,
+        policy_contents: &[(PathBuf, String)],
+    ) -> Result<Vec<String>, MegaError> {
+        // Convert PathBuf to String for the aggregate function
+        let policy_contents_str: Vec<(String, String)> = policy_contents
+            .iter()
+            .map(|(path, content)| (path.to_string_lossy().to_string(), content.clone()))
+            .collect();
+
+        // Use override-aware merge: same pattern from child overrides parent
+        let all_reviewers = aggregate_reviewers(&policy_contents_str, cl_path);
+
+        if all_reviewers.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // Get existing reviewers to avoid duplicates
+        let existing_reviewers: Vec<String> = self
+            .reviewer_storage
+            .list_reviewers(cl_link)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(|r| r.username)
+            .collect();
+
+        // Filter out already existing reviewers
+        let new_reviewers: Vec<String> = all_reviewers
+            .iter()
+            .filter(|r| !existing_reviewers.contains(r))
+            .cloned()
+            .collect();
+
+        if !new_reviewers.is_empty() {
+            self.reviewer_storage
+                .add_reviewers(cl_link, new_reviewers)
+                .await?;
+        }
+
+        // Mark all as system required
+        self.reviewer_storage
+            .update_system_required_reviewers(cl_link, &all_reviewers, true)
+            .await?;
+
+        Ok(all_reviewers)
+    }
+
+    /// Sync system required reviewers when policy files are updated
+    ///
+    /// This method:
+    /// 1. Removes all current system_required reviewers
+    /// 2. Aggregates reviewers from hierarchical policy files (same pattern: child wins, different patterns: merge)
+    /// 3. Adds new reviewers as system_required
+    ///
+    /// # Arguments
+    /// * `cl_link` - The CL link identifier
+    /// * `cl_path` - The path of the CL
+    /// * `policy_contents` - List of (policy_path, content) tuples, from root to leaf
+    pub async fn sync_system_reviewers(
+        &self,
+        cl_link: &str,
+        cl_path: &str,
+        policy_contents: &[(PathBuf, String)],
+    ) -> Result<(), MegaError> {
+        // 1. Get and remove all current system_required reviewers
+        let current_system: Vec<String> = self
+            .reviewer_storage
+            .list_reviewers(cl_link)
+            .await?
+            .into_iter()
+            .filter(|r| r.system_required)
+            .map(|r| r.username)
+            .collect();
+
+        if !current_system.is_empty() {
+            self.reviewer_storage
+                .remove_system_reviewers(cl_link, &current_system)
+                .await?;
+        }
+
+        // 2. Aggregate reviewers from hierarchical policies
+        let policy_contents_str: Vec<(String, String)> = policy_contents
+            .iter()
+            .map(|(path, content)| (path.to_string_lossy().to_string(), content.clone()))
+            .collect();
+
+        let new_reviewers = aggregate_reviewers(&policy_contents_str, cl_path);
+
+        // 3. Add new system reviewers
+        if !new_reviewers.is_empty() {
+            self.reviewer_storage
+                .add_reviewers(cl_link, new_reviewers.clone())
+                .await?;
+            self.reviewer_storage
+                .update_system_required_reviewers(cl_link, &new_reviewers, true)
+                .await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::test_storage;
+    use callisto::mega_cl_reviewer;
+    use tempfile::tempdir;
+
+    fn make_policy(path: &str, reviewers: &[&str]) -> String {
+        let reviewer_list = reviewers
+            .iter()
+            .map(|r| format!("\"{}\"", r))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            r#"permit(action == "code:review", principal, resource)
+    when {{ resource.path.startsWith("{}") }}
+    to [{}];"#,
+            path, reviewer_list
+        )
+    }
+
+    fn print_table(reviewers: &[mega_cl_reviewer::Model]) {
+        if reviewers.is_empty() {
+            println!("    (empty)");
+            return;
+        }
+        println!("    +-----------+-----------------+----------+");
+        println!("    | username  | system_required | approved |");
+        println!("    +-----------+-----------------+----------+");
+        for r in reviewers {
+            println!(
+                "    | {:9} | {:15} | {:8} |",
+                r.username, r.system_required, r.approved
+            );
+        }
+        println!("    +-----------+-----------------+----------+");
+    }
+
+    /// Comprehensive test for ReviewerService
+    /// Run with: cargo test -p jupiter test_reviewer_service -- --nocapture
+    #[tokio::test]
+    async fn test_reviewer_service() {
+        let temp = tempdir().unwrap();
+        let storage = test_storage(&temp).await;
+        let reviewer_storage = storage.reviewer_storage();
+        let service = ReviewerService::from_storage(reviewer_storage.clone());
+
+        println!("\n{}", "=".repeat(70));
+        println!("Reviewer Service - Comprehensive Test");
+        println!("{}", "=".repeat(70));
+
+        let cl_link = "test_cl_001";
+        let cl_path = "service_a/src/main.rs";
+
+        // ========== 1. Assign System Reviewers ==========
+        println!("\n[1] Assign System Reviewers (CL creation)");
+        println!("{}", "-".repeat(50));
+
+        let policy = make_policy("service_a/", &["alice", "bob"]);
+        println!("    Policy: service_a/ -> [alice, bob]");
+        println!("    CL path: {}", cl_path);
+
+        let assigned = service
+            .assign_system_reviewers(cl_link, cl_path, &[(PathBuf::from("/repo"), policy)])
+            .await
+            .unwrap();
+
+        println!("    Assigned: {:?}", assigned);
+        let reviewers = reviewer_storage.list_reviewers(cl_link).await.unwrap();
+        print_table(&reviewers);
+
+        assert_eq!(assigned.len(), 2);
+        assert!(reviewers.iter().all(|r| r.system_required));
+        println!("✓ System reviewers assigned with system_required=true");
+
+        // ========== 2. Sync: Policy Update ==========
+        println!("\n[2] Sync: Policy adds 'charlie', removes 'bob'");
+        println!("{}", "-".repeat(50));
+
+        let new_policy = make_policy("service_a/", &["alice", "charlie"]);
+        println!("    New policy: service_a/ -> [alice, charlie]");
+
+        service
+            .sync_system_reviewers(cl_link, cl_path, &[(PathBuf::from("/repo"), new_policy)])
+            .await
+            .unwrap();
+
+        let reviewers = reviewer_storage.list_reviewers(cl_link).await.unwrap();
+        print_table(&reviewers);
+
+        assert_eq!(reviewers.len(), 2);
+        assert!(reviewers.iter().any(|r| r.username == "alice"));
+        assert!(reviewers.iter().any(|r| r.username == "charlie"));
+        assert!(!reviewers.iter().any(|r| r.username == "bob"));
+        println!("✓ Sync correctly added/removed system reviewers");
+
+        // ========== 3. Manual Reviewer Not Affected by Sync ==========
+        println!("\n[3] Manual Reviewer Not Affected by Policy Sync");
+        println!("{}", "-".repeat(50));
+
+        // Add bob manually
+        reviewer_storage
+            .add_reviewers(cl_link, vec!["bob".to_string()])
+            .await
+            .unwrap();
+        println!("    Added 'bob' manually (system_required=false)");
+
+        let reviewers = reviewer_storage.list_reviewers(cl_link).await.unwrap();
+        print_table(&reviewers);
+
+        // Sync with policy that only has alice
+        let new_policy = make_policy("service_a/", &["alice"]);
+        println!("\n    Sync with policy: service_a/ -> [alice] only");
+        println!("    Expected: charlie removed (system), bob preserved (manual)");
+
+        service
+            .sync_system_reviewers(cl_link, cl_path, &[(PathBuf::from("/repo"), new_policy)])
+            .await
+            .unwrap();
+
+        let reviewers = reviewer_storage.list_reviewers(cl_link).await.unwrap();
+        print_table(&reviewers);
+
+        assert_eq!(reviewers.len(), 2);
+        assert!(
+            reviewers
+                .iter()
+                .any(|r| r.username == "alice" && r.system_required)
+        );
+        assert!(
+            reviewers
+                .iter()
+                .any(|r| r.username == "bob" && !r.system_required)
+        );
+        println!("✓ Manual reviewer preserved, system reviewer removed");
+
+        // ========== 4. Hierarchical Policy Merge ==========
+        println!("\n[4] Hierarchical Policy Merge");
+        println!("{}", "-".repeat(50));
+
+        let cl_link2 = "test_cl_002";
+        let root_policy = make_policy("", &["root_owner"]);
+        let service_policy = make_policy("service_a/", &["alice"]);
+
+        println!("    Root policy: '' -> [root_owner]");
+        println!("    Child policy: service_a/ -> [alice]");
+        println!("    CL path: service_a/core/lib.rs");
+
+        let policies = vec![
+            (PathBuf::from("/repo"), root_policy),
+            (PathBuf::from("/repo/service_a"), service_policy),
+        ];
+
+        let assigned = service
+            .assign_system_reviewers(cl_link2, "service_a/core/lib.rs", &policies)
+            .await
+            .unwrap();
+
+        println!("    Assigned: {:?}", assigned);
+        let reviewers = reviewer_storage.list_reviewers(cl_link2).await.unwrap();
+        print_table(&reviewers);
+
+        assert_eq!(assigned.len(), 2);
+        assert!(assigned.contains(&"root_owner".to_string()));
+        assert!(assigned.contains(&"alice".to_string()));
+        println!("✓ Different patterns merged correctly");
+
+        // ========== Summary ==========
+        println!("\n{}", "=".repeat(70));
+        println!("ALL TESTS PASSED!");
+        println!("{}", "=".repeat(70));
+        println!("\nCore features tested:");
+        println!("  - assign_system_reviewers: CL creation assigns reviewers");
+        println!("  - sync_system_reviewers: Policy update replaces system reviewers");
+        println!("  - Manual reviewers (system_required=false) not affected by sync");
+        println!("  - Hierarchical policy merge (different patterns)");
+        println!();
+    }
+
+    /// Integration test simulating full monorepo hierarchical policy scenario
+    /// This test simulates the complete flow as if policies were read from actual files
+    /// Run with: cargo test -p jupiter test_monorepo_hierarchical_policies -- --nocapture
+    #[tokio::test]
+    async fn test_monorepo_hierarchical_policies() {
+        let temp = tempdir().unwrap();
+        let storage = test_storage(&temp).await;
+        let reviewer_storage = storage.reviewer_storage();
+        let service = ReviewerService::from_storage(reviewer_storage.clone());
+
+        println!("\n{}", "=".repeat(70));
+        println!("Monorepo Hierarchical Policy Integration Test");
+        println!("{}", "=".repeat(70));
+
+        // Simulate monorepo structure:
+        // /
+        // ├── .cedar/policies.cedar           -> ["global_owner"], ["service_a/" -> "old_alice"]
+        // ├── service_a/
+        // │   ├── .cedar/policies.cedar       -> ["service_a/" -> "alice", "bob"] (overrides root)
+        // │   └── core/
+        // │       ├── .cedar/policies.cedar   -> ["service_a/core/" -> "core_expert"]
+        // │       └── main.rs
+        // └── service_b/
+        //     └── handler.rs
+
+        println!("\n[Scenario] Three-level policy hierarchy with override");
+        println!("{}", "-".repeat(50));
+        println!("  /");
+        println!("  ├── .cedar/policies.cedar");
+        println!("  │   └── '' -> [global_owner]");
+        println!("  │   └── 'service_a/' -> [old_alice] (will be overridden)");
+        println!("  ├── service_a/");
+        println!("  │   ├── .cedar/policies.cedar");
+        println!("  │   │   └── 'service_a/' -> [alice, bob] (overrides root)");
+        println!("  │   └── core/");
+        println!("  │       ├── .cedar/policies.cedar");
+        println!("  │       │   └── 'service_a/core/' -> [core_expert]");
+        println!("  │       └── main.rs");
+        println!("  └── service_b/");
+        println!("      └── handler.rs");
+
+        // ========== Test Case 1: Deep nested path (service_a/core/main.rs) ==========
+        println!("\n[1] CL in service_a/core/main.rs");
+        println!("{}", "-".repeat(50));
+
+        let cl_link1 = "monorepo_cl_001";
+        let cl_path1 = "service_a/core/main.rs";
+
+        // Simulate policies collected from root to leaf
+        let root_policy = format!(
+            r#"{}
+{}"#,
+            make_policy("", &["global_owner"]),
+            make_policy("service_a/", &["old_alice"])
+        );
+        let service_a_policy = make_policy("service_a/", &["alice", "bob"]);
+        let core_policy = make_policy("service_a/core/", &["core_expert"]);
+
+        let policies = vec![
+            (PathBuf::from("/.cedar/policies.cedar"), root_policy),
+            (
+                PathBuf::from("/service_a/.cedar/policies.cedar"),
+                service_a_policy,
+            ),
+            (
+                PathBuf::from("/service_a/core/.cedar/policies.cedar"),
+                core_policy,
+            ),
+        ];
+
+        println!("    Policies (root to leaf):");
+        println!("      - Root: '' -> [global_owner], 'service_a/' -> [old_alice]");
+        println!("      - service_a: 'service_a/' -> [alice, bob] (overrides old_alice)");
+        println!("      - core: 'service_a/core/' -> [core_expert]");
+        println!("    CL path: {}", cl_path1);
+
+        let assigned = service
+            .assign_system_reviewers(cl_link1, cl_path1, &policies)
+            .await
+            .unwrap();
+
+        println!("\n    Assigned reviewers: {:?}", assigned);
+        let reviewers = reviewer_storage.list_reviewers(cl_link1).await.unwrap();
+        print_table(&reviewers);
+
+        // Verify: global_owner (from ""), alice+bob (from service_a, overrides old_alice), core_expert (from core)
+        assert!(
+            assigned.contains(&"global_owner".to_string()),
+            "Should have global_owner"
+        );
+        assert!(assigned.contains(&"alice".to_string()), "Should have alice");
+        assert!(assigned.contains(&"bob".to_string()), "Should have bob");
+        assert!(
+            assigned.contains(&"core_expert".to_string()),
+            "Should have core_expert"
+        );
+        assert!(
+            !assigned.contains(&"old_alice".to_string()),
+            "old_alice should be overridden"
+        );
+        println!(
+            "✓ Three-level hierarchy: global_owner + alice + bob + core_expert (old_alice overridden)"
+        );
+
+        // ========== Test Case 2: Service B path (no service-specific policy) ==========
+        println!("\n[2] CL in service_b/handler.rs (no service-specific policy)");
+        println!("{}", "-".repeat(50));
+
+        let cl_link2 = "monorepo_cl_002";
+        let cl_path2 = "service_b/handler.rs";
+
+        let root_policy_only = make_policy("", &["global_owner"]);
+        let policies2 = vec![(PathBuf::from("/.cedar/policies.cedar"), root_policy_only)];
+
+        println!("    Only root policy: '' -> [global_owner]");
+        println!("    CL path: {}", cl_path2);
+
+        let assigned2 = service
+            .assign_system_reviewers(cl_link2, cl_path2, &policies2)
+            .await
+            .unwrap();
+
+        println!("\n    Assigned reviewers: {:?}", assigned2);
+        let reviewers2 = reviewer_storage.list_reviewers(cl_link2).await.unwrap();
+        print_table(&reviewers2);
+
+        assert_eq!(assigned2.len(), 1);
+        assert!(assigned2.contains(&"global_owner".to_string()));
+        println!("✓ Only global_owner assigned (no service-specific policy)");
+
+        // ========== Test Case 3: Same pattern override verification ==========
+        println!("\n[3] Same pattern override: child wins");
+        println!("{}", "-".repeat(50));
+
+        let cl_link3 = "monorepo_cl_003";
+        let cl_path3 = "service_a/src/lib.rs";
+
+        let root_policy3 = make_policy("service_a/", &["root_reviewer"]);
+        let child_policy3 = make_policy("service_a/", &["child_reviewer"]);
+
+        let policies3 = vec![
+            (PathBuf::from("/.cedar/policies.cedar"), root_policy3),
+            (
+                PathBuf::from("/service_a/.cedar/policies.cedar"),
+                child_policy3,
+            ),
+        ];
+
+        println!("    Root: 'service_a/' -> [root_reviewer]");
+        println!("    Child: 'service_a/' -> [child_reviewer] (same pattern, should override)");
+        println!("    CL path: {}", cl_path3);
+
+        let assigned3 = service
+            .assign_system_reviewers(cl_link3, cl_path3, &policies3)
+            .await
+            .unwrap();
+
+        println!("\n    Assigned reviewers: {:?}", assigned3);
+        let reviewers3 = reviewer_storage.list_reviewers(cl_link3).await.unwrap();
+        print_table(&reviewers3);
+
+        assert_eq!(assigned3.len(), 1);
+        assert!(
+            assigned3.contains(&"child_reviewer".to_string()),
+            "child_reviewer should win"
+        );
+        assert!(
+            !assigned3.contains(&"root_reviewer".to_string()),
+            "root_reviewer should be overridden"
+        );
+        println!("✓ Same pattern override: child_reviewer wins, root_reviewer overridden");
+
+        // ========== Summary ==========
+        println!("\n{}", "=".repeat(70));
+        println!("MONOREPO INTEGRATION TEST PASSED!");
+        println!("{}", "=".repeat(70));
+        println!("\nTested scenarios:");
+        println!("  - Three-level policy hierarchy (root -> service -> module)");
+        println!("  - Same pattern override: child directory wins");
+        println!("  - Different patterns merge: all applicable rules combined");
+        println!("  - Path without service-specific policy: only root policy applies");
+        println!();
+    }
+
+    /// Test simulating policy file modification in CL update
+    /// This tests the scenario where resync_current_cl_reviewers_if_policy_changed is triggered
+    /// Run with: cargo test -p jupiter test_policy_file_modification_resync -- --nocapture
+    #[tokio::test]
+    async fn test_policy_file_modification_resync() {
+        let temp = tempdir().unwrap();
+        let storage = test_storage(&temp).await;
+        let reviewer_storage = storage.reviewer_storage();
+        let service = ReviewerService::from_storage(reviewer_storage.clone());
+
+        println!("\n{}", "=".repeat(70));
+        println!("Policy File Modification Resync Test");
+        println!("{}", "=".repeat(70));
+
+        let cl_link = "policy_update_cl_001";
+        let cl_path = "service_a/src/main.rs";
+
+        // ========== 1. Initial CL Creation ==========
+        println!("\n[1] Initial CL Creation with Policy");
+        println!("{}", "-".repeat(50));
+
+        let initial_policy = make_policy("service_a/", &["alice", "bob"]);
+        println!("    Initial policy: service_a/ -> [alice, bob]");
+
+        let assigned = service
+            .assign_system_reviewers(
+                cl_link,
+                cl_path,
+                &[(PathBuf::from("/repo"), initial_policy)],
+            )
+            .await
+            .unwrap();
+
+        println!("    Assigned: {:?}", assigned);
+        let reviewers = reviewer_storage.list_reviewers(cl_link).await.unwrap();
+        print_table(&reviewers);
+
+        assert_eq!(assigned.len(), 2);
+        assert!(
+            reviewers
+                .iter()
+                .any(|r| r.username == "alice" && r.system_required)
+        );
+        assert!(
+            reviewers
+                .iter()
+                .any(|r| r.username == "bob" && r.system_required)
+        );
+        println!("✓ Initial reviewers assigned");
+
+        // ========== 2. Simulate Policy File Modification ==========
+        println!("\n[2] Simulate Policy File Modification in CL Update");
+        println!("{}", "-".repeat(50));
+        println!("    Scenario: User pushes update that modifies .cedar/policies.cedar");
+        println!("    Changed files would include: service_a/.cedar/policies.cedar");
+
+        // New policy: removes bob, adds charlie and david
+        let updated_policy = make_policy("service_a/", &["alice", "charlie", "david"]);
+        println!("    Updated policy: service_a/ -> [alice, charlie, david]");
+
+        // This simulates what resync_current_cl_reviewers_if_policy_changed does
+        // when it detects policy file in changed_files
+        service
+            .sync_system_reviewers(
+                cl_link,
+                cl_path,
+                &[(PathBuf::from("/repo"), updated_policy)],
+            )
+            .await
+            .unwrap();
+
+        let reviewers = reviewer_storage.list_reviewers(cl_link).await.unwrap();
+        print_table(&reviewers);
+
+        assert_eq!(reviewers.len(), 3);
+        assert!(reviewers.iter().any(|r| r.username == "alice"));
+        assert!(reviewers.iter().any(|r| r.username == "charlie"));
+        assert!(reviewers.iter().any(|r| r.username == "david"));
+        assert!(!reviewers.iter().any(|r| r.username == "bob")); // bob removed
+        println!("✓ Reviewers resynced after policy modification");
+
+        // ========== 3. Multiple Policy Updates ==========
+        println!("\n[3] Multiple Policy Updates (Hierarchical)");
+        println!("{}", "-".repeat(50));
+
+        let cl_link2 = "policy_update_cl_002";
+        let cl_path2 = "service_a/core/handler.rs";
+
+        // Initial: only root policy
+        let root_policy = make_policy("", &["global_owner"]);
+        println!("    Initial: Only root policy '' -> [global_owner]");
+
+        service
+            .assign_system_reviewers(
+                cl_link2,
+                cl_path2,
+                &[(PathBuf::from("/repo"), root_policy.clone())],
+            )
+            .await
+            .unwrap();
+
+        let reviewers = reviewer_storage.list_reviewers(cl_link2).await.unwrap();
+        print_table(&reviewers);
+        assert_eq!(reviewers.len(), 1);
+        println!("✓ Only global_owner initially");
+
+        // Update: add service_a policy file
+        println!("\n    Update: Add service_a/.cedar/policies.cedar");
+        let service_policy = make_policy("service_a/", &["service_lead"]);
+        println!("    New policy: service_a/ -> [service_lead]");
+
+        let policies = vec![
+            (PathBuf::from("/repo"), root_policy),
+            (PathBuf::from("/repo/service_a"), service_policy),
+        ];
+
+        service
+            .sync_system_reviewers(cl_link2, cl_path2, &policies)
+            .await
+            .unwrap();
+
+        let reviewers = reviewer_storage.list_reviewers(cl_link2).await.unwrap();
+        print_table(&reviewers);
+
+        assert_eq!(reviewers.len(), 2);
+        assert!(reviewers.iter().any(|r| r.username == "global_owner"));
+        assert!(reviewers.iter().any(|r| r.username == "service_lead"));
+        println!("✓ Both global_owner and service_lead after adding service policy");
+
+        // ========== 4. Policy Deletion Scenario ==========
+        println!("\n[4] Policy Deletion Scenario");
+        println!("{}", "-".repeat(50));
+        println!("    Scenario: service_a policy is deleted, only root policy remains");
+
+        let root_only = make_policy("", &["global_owner"]);
+        service
+            .sync_system_reviewers(cl_link2, cl_path2, &[(PathBuf::from("/repo"), root_only)])
+            .await
+            .unwrap();
+
+        let reviewers = reviewer_storage.list_reviewers(cl_link2).await.unwrap();
+        print_table(&reviewers);
+
+        assert_eq!(reviewers.len(), 1);
+        assert!(reviewers.iter().any(|r| r.username == "global_owner"));
+        assert!(!reviewers.iter().any(|r| r.username == "service_lead")); // removed
+        println!("✓ service_lead removed after policy deletion");
+
+        // ========== Summary ==========
+        println!("\n{}", "=".repeat(70));
+        println!("POLICY FILE MODIFICATION RESYNC TEST PASSED!");
+        println!("{}", "=".repeat(70));
+        println!("\nTested scenarios:");
+        println!("  - Policy modification: reviewers resynced with new policy");
+        println!("  - Policy addition: new policy reviewers added");
+        println!("  - Policy deletion: removed policy reviewers cleaned up");
+        println!("  - Manual reviewers preserved during resync");
+        println!();
+    }
+
+    /// Test is_policy_file detection logic
+    /// Run with: cargo test -p jupiter test_is_policy_file_detection -- --nocapture
+    #[test]
+    fn test_is_policy_file_detection() {
+        println!("\n{}", "=".repeat(70));
+        println!("Policy File Detection Test");
+        println!("{}", "=".repeat(70));
+
+        fn is_policy_file(path: &str) -> bool {
+            path.ends_with(".cedar/policies.cedar") || path.ends_with(".cedar\\policies.cedar")
+        }
+
+        let test_cases = vec![
+            // Valid policy files
+            (".cedar/policies.cedar", true),
+            ("service_a/.cedar/policies.cedar", true),
+            ("service_a/submodule/.cedar/policies.cedar", true),
+            // Windows path
+            ("service_a\\.cedar\\policies.cedar", true),
+            // Non-policy files
+            ("service_a/src/main.rs", false),
+            ("README.md", false),
+            (".cedar/other.cedar", false),
+            ("policies.cedar", false),
+            ("service_a/.cedar/policies.json", false),
+        ];
+
+        for (path, expected) in test_cases {
+            let result = is_policy_file(path);
+            println!("    '{}' -> {} (expected: {})", path, result, expected);
+            assert_eq!(result, expected, "Failed for path: {}", path);
+        }
+
+        println!("\n✓ All policy file detection tests passed!");
+        println!("{}", "=".repeat(70));
+    }
+}

--- a/jupiter/src/storage/cl_storage.rs
+++ b/jupiter/src/storage/cl_storage.rs
@@ -49,6 +49,18 @@ impl ClStorage {
         Ok(model)
     }
 
+    pub async fn get_open_cls_by_path_prefix(
+        &self,
+        path_prefix: &str,
+    ) -> Result<Vec<mega_cl::Model>, MegaError> {
+        let models = mega_cl::Entity::find()
+            .filter(mega_cl::Column::Path.starts_with(path_prefix))
+            .filter(mega_cl::Column::Status.eq(MergeStatusEnum::Open))
+            .all(self.get_connection())
+            .await?;
+        Ok(models)
+    }
+
     pub async fn get_cl_list(
         &self,
         params: ListParams,

--- a/mono/src/api/api_router.rs
+++ b/mono/src/api/api_router.rs
@@ -18,7 +18,8 @@ use crate::api::{
     notes::note_router,
     router::{
         cl_router, commit_router, conv_router, dynamic_sidebar_router, gpg_router, issue_router,
-        label_router, merge_queue_router, preview_router, repo_router, tag_router, user_router,
+        label_router, merge_queue_router, preview_router, repo_router, reviewer_router, tag_router,
+        user_router,
     },
 };
 use crate::server::http_server::SYSTEM_COMMON;
@@ -30,6 +31,7 @@ pub fn routers() -> OpenApiRouter<MonoApiServiceState> {
         .route("/file/tree", get(get_tree_file))
         .merge(preview_router::routers())
         .merge(cl_router::routers())
+        .merge(reviewer_router::routers())
         .merge(gpg_router::routers())
         .merge(user_router::routers())
         .merge(issue_router::routers())

--- a/mono/src/api/router/cl_router.rs
+++ b/mono/src/api/router/cl_router.rs
@@ -6,8 +6,7 @@ use axum::{
 };
 use callisto::sea_orm_active_enums::{ConvTypeEnum, MergeStatusEnum};
 use ceres::model::change_list::{
-    CLDetailRes, ChangeReviewStatePayload, ChangeReviewerStatePayload, ClFilesRes, Condition,
-    FilesChangedPage, MergeBoxRes, MuiTreeNode, ReviewerInfo, ReviewerPayload, ReviewersResponse,
+    CLDetailRes, ClFilesRes, Condition, FilesChangedPage, MergeBoxRes, MuiTreeNode,
     UpdateClStatusPayload,
 };
 use common::{
@@ -32,7 +31,6 @@ use crate::api::{
 
 use crate::{api::error::ApiError, server::http_server::CL_TAG};
 
-const ERR_CL_NOT_READY_FOR_REVIEW: &str = "CL is not ready for review";
 pub fn routers() -> OpenApiRouter<MonoApiServiceState> {
     OpenApiRouter::new().nest(
         "/cl",
@@ -51,11 +49,6 @@ pub fn routers() -> OpenApiRouter<MonoApiServiceState> {
             .routes(routes!(labels))
             .routes(routes!(assignees))
             .routes(routes!(edit_title))
-            .routes(routes!(add_reviewers))
-            .routes(routes!(remove_reviewers))
-            .routes(routes!(list_reviewers))
-            .routes(routes!(reviewer_approve))
-            .routes(routes!(review_resolve))
             .routes(routes!(update_cl_status)),
     )
 }
@@ -172,7 +165,7 @@ async fn merge(
 
     if model.status == MergeStatusEnum::Draft {
         return Err(ApiError::from(MegaError::Other(
-            ERR_CL_NOT_READY_FOR_REVIEW.to_owned(),
+            "CL is not ready for review".to_owned(),
         )));
     }
 
@@ -509,221 +502,7 @@ async fn assignees(
     api_common::label_assignee::assignees_update(user, state, payload, String::from("cl")).await
 }
 
-#[utoipa::path(
-    post,
-    params (
-        ("link", description = "the cl link")
-    ),
-    path = "/{link}/reviewers",
-    request_body = ReviewerPayload,
-    responses(
-        (status = 200, body = CommonResult<String>, content_type = "application/json")
-    ),
-    tag = CL_TAG
-)]
-async fn add_reviewers(
-    user: LoginUser,
-    Path(link): Path<String>,
-    state: State<MonoApiServiceState>,
-    Json(payload): Json<ReviewerPayload>,
-) -> Result<Json<CommonResult<String>>, ApiError> {
-    state
-        .storage
-        .reviewer_storage()
-        .add_reviewers(&link, payload.reviewer_usernames.clone())
-        .await?;
-
-    for reviewer in payload.reviewer_usernames {
-        state
-            .conv_stg()
-            .add_conversation(
-                &link,
-                &user.username,
-                Some(format!(
-                    "{} assigned a new reviewer {}",
-                    user.username, reviewer
-                )),
-                ConvTypeEnum::Comment,
-            )
-            .await?;
-    }
-
-    Ok(Json(CommonResult::success(None)))
-}
-
-#[utoipa::path(
-    delete,
-    params (
-        ("link", description = "the cl link"),
-    ),
-    path = "/{link}/reviewers",
-    request_body = ReviewerPayload,
-    responses(
-        (status = 200, body = CommonResult<String>, content_type = "application/json")
-    ),
-    tag = CL_TAG
-)]
-async fn remove_reviewers(
-    user: LoginUser,
-    Path(link): Path<String>,
-    state: State<MonoApiServiceState>,
-    Json(payload): Json<ReviewerPayload>,
-) -> Result<Json<CommonResult<String>>, ApiError> {
-    state
-        .storage
-        .reviewer_storage()
-        .remove_reviewers(&link, &payload.reviewer_usernames)
-        .await?;
-
-    for reviewer in &payload.reviewer_usernames {
-        state
-            .conv_stg()
-            .add_conversation(
-                &link,
-                &user.username,
-                Some(format!("{} removed reviewer {}", user.username, reviewer)),
-                ConvTypeEnum::Comment,
-            )
-            .await?;
-    }
-
-    Ok(Json(CommonResult::success(None)))
-}
-
-#[utoipa::path(
-    get,
-    params (
-        ("link", description = "the cl link")
-    ),
-    path = "/{link}/reviewers",
-    responses(
-        (status = 200, body = CommonResult<ReviewersResponse>, content_type = "application/json")
-    ),
-    tag = CL_TAG
-)]
-async fn list_reviewers(
-    Path(link): Path<String>,
-    state: State<MonoApiServiceState>,
-) -> Result<Json<CommonResult<ReviewersResponse>>, ApiError> {
-    let reviewers = state
-        .storage
-        .reviewer_storage()
-        .list_reviewers(&link)
-        .await?
-        .into_iter()
-        .map(|r| ReviewerInfo {
-            username: r.username,
-            approved: r.approved,
-            system_required: r.system_required,
-        })
-        .collect();
-
-    Ok(Json(CommonResult::success(Some(ReviewersResponse {
-        result: reviewers,
-    }))))
-}
-
-/// Change the reviewer state
-///
-/// the function get user's campsite_id from the login user info automatically
-#[utoipa::path(
-    post,
-    params (
-        ("link", description = "the cl link")
-    ),
-    path = "/{link}/reviewer/approve",
-    request_body = ChangeReviewerStatePayload,
-    responses(
-        (status = 200, body = CommonResult<String>, content_type = "application/json")
-    ),
-    tag = CL_TAG
-)]
-async fn reviewer_approve(
-    user: LoginUser,
-    Path(link): Path<String>,
-    state: State<MonoApiServiceState>,
-    Json(payload): Json<ChangeReviewerStatePayload>,
-) -> Result<Json<CommonResult<()>>, ApiError> {
-    let res = state.cl_stg().get_cl(&link).await?;
-    let model = res.ok_or(MegaError::Other("CL Not Found".to_string()))?;
-
-    if model.status == MergeStatusEnum::Draft {
-        return Err(ApiError::from(MegaError::Other(
-            ERR_CL_NOT_READY_FOR_REVIEW.to_owned(),
-        )));
-    }
-
-    state
-        .storage
-        .reviewer_storage()
-        .reviewer_change_state(&link, &user.username, payload.approved)
-        .await?;
-
-    state
-        .conv_stg()
-        .add_conversation(
-            &link,
-            &user.username,
-            Some(format!("{} approved the CL", user.username)),
-            ConvTypeEnum::Approve,
-        )
-        .await?;
-
-    Ok(Json(CommonResult::success(None)))
-}
-
-#[utoipa::path(
-    post,
-    params (
-        ("link", description = "the cl link")
-    ),
-    path = "/{link}/review/resolve",
-    request_body (
-        content = ChangeReviewStatePayload,
-    ),
-    responses(
-        (status = 200, body = CommonResult<String>, content_type = "application/json")
-    ),
-    tag = CL_TAG
-)]
-async fn review_resolve(
-    user: LoginUser,
-    state: State<MonoApiServiceState>,
-    Path(link): Path<String>,
-    Json(payload): Json<ChangeReviewStatePayload>,
-) -> Result<Json<CommonResult<String>>, ApiError> {
-    let res = state
-        .storage
-        .reviewer_storage()
-        .is_reviewer(&link, &user.username)
-        .await?;
-
-    if !res {
-        return Err(ApiError::from(MegaError::Other(
-            "Only reviewer can resolve the review comments".to_string(),
-        )));
-    }
-
-    state
-        .storage
-        .conversation_storage()
-        .change_review_state(&link, &payload.conversation_id, payload.resolved)
-        .await?;
-
-    state
-        .conv_stg()
-        .add_conversation(
-            &link,
-            &user.username,
-            Some(format!("{} resolved a review", user.username)),
-            ConvTypeEnum::Comment,
-        )
-        .await?;
-
-    Ok(Json(CommonResult::success(None)))
-}
-
-/// Update CL status (Draft ↔ Open)
+/// Update CL status (Draft or Open)
 #[utoipa::path(
     post,
     params(

--- a/mono/src/api/router/mod.rs
+++ b/mono/src/api/router/mod.rs
@@ -9,5 +9,6 @@ pub mod lfs_router;
 pub mod merge_queue_router;
 pub mod preview_router;
 pub mod repo_router;
+pub mod reviewer_router;
 pub mod tag_router;
 pub mod user_router;

--- a/mono/src/api/router/reviewer_router.rs
+++ b/mono/src/api/router/reviewer_router.rs
@@ -1,0 +1,258 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+};
+use callisto::sea_orm_active_enums::{ConvTypeEnum, MergeStatusEnum};
+use ceres::model::change_list::{
+    ChangeReviewStatePayload, ChangeReviewerStatePayload, ReviewerInfo, ReviewerPayload,
+    ReviewersResponse,
+};
+use common::{errors::MegaError, model::CommonResult};
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+use crate::api::MonoApiServiceState;
+use crate::api::error::ApiError;
+use crate::api::oauth::model::LoginUser;
+use crate::server::http_server::CL_TAG;
+
+const ERR_CL_NOT_READY_FOR_REVIEW: &str = "CL is not ready for review";
+
+pub fn routers() -> OpenApiRouter<MonoApiServiceState> {
+    OpenApiRouter::new().nest(
+        "/cl",
+        OpenApiRouter::new()
+            .routes(routes!(add_reviewers))
+            .routes(routes!(remove_reviewers))
+            .routes(routes!(list_reviewers))
+            .routes(routes!(reviewer_approve))
+            .routes(routes!(review_resolve)),
+    )
+}
+
+#[utoipa::path(
+    post,
+    params(
+        ("link", description = "the cl link"),
+    ),
+    path = "/{link}/reviewers",
+    request_body = ReviewerPayload,
+    responses(
+        (status = 200, body = CommonResult<String>, content_type = "application/json")
+    ),
+    tag = CL_TAG
+)]
+async fn add_reviewers(
+    user: LoginUser,
+    Path(link): Path<String>,
+    state: State<MonoApiServiceState>,
+    Json(payload): Json<ReviewerPayload>,
+) -> Result<Json<CommonResult<String>>, ApiError> {
+    state
+        .storage
+        .reviewer_storage()
+        .add_reviewers(&link, payload.reviewer_usernames.clone())
+        .await?;
+
+    // Audit log
+    tracing::info!(
+        "[Audit] event=reviewer_added cl_link={} reviewers={:?} actor={}",
+        link,
+        payload.reviewer_usernames,
+        user.username
+    );
+
+    for reviewer in payload.reviewer_usernames {
+        state
+            .conv_stg()
+            .add_conversation(
+                &link,
+                &user.username,
+                Some(format!(
+                    "{} assigned a new reviewer {}",
+                    user.username, reviewer
+                )),
+                ConvTypeEnum::Comment,
+            )
+            .await?;
+    }
+
+    Ok(Json(CommonResult::success(None)))
+}
+
+#[utoipa::path(
+    delete,
+    params (
+        ("link", description = "the cl link"),
+    ),
+    path = "/{link}/reviewers",
+    request_body = ReviewerPayload,
+    responses(
+        (status = 200, body = CommonResult<String>, content_type = "application/json")
+    ),
+    tag = CL_TAG
+)]
+async fn remove_reviewers(
+    user: LoginUser,
+    Path(link): Path<String>,
+    state: State<MonoApiServiceState>,
+    Json(payload): Json<ReviewerPayload>,
+) -> Result<Json<CommonResult<String>>, ApiError> {
+    state
+        .storage
+        .reviewer_storage()
+        .remove_reviewers(&link, &payload.reviewer_usernames)
+        .await?;
+
+    // Audit log
+    tracing::info!(
+        "[Audit] event=reviewer_removed cl_link={} reviewers={:?} actor={}",
+        link,
+        payload.reviewer_usernames,
+        user.username
+    );
+
+    for reviewer in &payload.reviewer_usernames {
+        state
+            .conv_stg()
+            .add_conversation(
+                &link,
+                &user.username,
+                Some(format!("{} removed reviewer {}", user.username, reviewer)),
+                ConvTypeEnum::Comment,
+            )
+            .await?;
+    }
+
+    Ok(Json(CommonResult::success(None)))
+}
+
+#[utoipa::path(
+    get,
+    params (
+        ("link", description = "the cl link")
+    ),
+    path = "/{link}/reviewers",
+    responses(
+        (status = 200, body = CommonResult<ReviewersResponse>, content_type = "application/json")
+    ),
+    tag = CL_TAG
+)]
+async fn list_reviewers(
+    Path(link): Path<String>,
+    state: State<MonoApiServiceState>,
+) -> Result<Json<CommonResult<ReviewersResponse>>, ApiError> {
+    let reviewers = state
+        .storage
+        .reviewer_storage()
+        .list_reviewers(&link)
+        .await?
+        .into_iter()
+        .map(|r| ReviewerInfo {
+            username: r.username,
+            approved: r.approved,
+            system_required: r.system_required,
+        })
+        .collect();
+
+    Ok(Json(CommonResult::success(Some(ReviewersResponse {
+        result: reviewers,
+    }))))
+}
+
+/// Change the reviewer approval state
+#[utoipa::path(
+    post,
+    params (
+        ("link", description = "the cl link")
+    ),
+    path = "/{link}/reviewer/approve",
+    request_body = ChangeReviewerStatePayload,
+    responses(
+        (status = 200, body = CommonResult<String>, content_type = "application/json")
+    ),
+    tag = CL_TAG
+)]
+async fn reviewer_approve(
+    user: LoginUser,
+    Path(link): Path<String>,
+    state: State<MonoApiServiceState>,
+    Json(payload): Json<ChangeReviewerStatePayload>,
+) -> Result<Json<CommonResult<()>>, ApiError> {
+    let res = state.cl_stg().get_cl(&link).await?;
+    let model = res.ok_or(MegaError::Other("CL Not Found".to_string()))?;
+
+    if model.status == MergeStatusEnum::Draft {
+        return Err(ApiError::from(MegaError::Other(
+            ERR_CL_NOT_READY_FOR_REVIEW.to_owned(),
+        )));
+    }
+
+    state
+        .storage
+        .reviewer_storage()
+        .reviewer_change_state(&link, &user.username, payload.approved)
+        .await?;
+
+    state
+        .conv_stg()
+        .add_conversation(
+            &link,
+            &user.username,
+            Some(format!("{} approved the CL", user.username)),
+            ConvTypeEnum::Approve,
+        )
+        .await?;
+
+    Ok(Json(CommonResult::success(None)))
+}
+
+#[utoipa::path(
+    post,
+    params (
+        ("link", description = "the cl link")
+    ),
+    path = "/{link}/review/resolve",
+    request_body (
+        content = ChangeReviewStatePayload,
+    ),
+    responses(
+        (status = 200, body = CommonResult<String>, content_type = "application/json")
+    ),
+    tag = CL_TAG
+)]
+async fn review_resolve(
+    user: LoginUser,
+    state: State<MonoApiServiceState>,
+    Path(link): Path<String>,
+    Json(payload): Json<ChangeReviewStatePayload>,
+) -> Result<Json<CommonResult<String>>, ApiError> {
+    let res = state
+        .storage
+        .reviewer_storage()
+        .is_reviewer(&link, &user.username)
+        .await?;
+
+    if !res {
+        return Err(ApiError::from(MegaError::Other(
+            "Only reviewer can resolve the review comments".to_string(),
+        )));
+    }
+
+    state
+        .storage
+        .conversation_storage()
+        .change_review_state(&link, &payload.conversation_id, payload.resolved)
+        .await?;
+
+    state
+        .conv_stg()
+        .add_conversation(
+            &link,
+            &user.username,
+            Some(format!("{} resolved a review", user.username)),
+            ConvTypeEnum::Comment,
+        )
+        .await?;
+
+    Ok(Json(CommonResult::success(None)))
+}

--- a/saturn/Cargo.toml
+++ b/saturn/Cargo.toml
@@ -11,3 +11,5 @@ tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 cedar-policy = { workspace = true }
 itertools = { workspace = true }
+regex = { workspace = true }
+lazy_static = { workspace = true }

--- a/saturn/src/lib.rs
+++ b/saturn/src/lib.rs
@@ -3,6 +3,7 @@ use std::fmt::{self, Display};
 pub mod context;
 pub mod entitystore;
 mod objects;
+pub mod reviewer_parser;
 pub mod util;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/saturn/src/reviewer_parser.rs
+++ b/saturn/src/reviewer_parser.rs
@@ -1,0 +1,532 @@
+//! Parser for extracting system required reviewers from Cedar policy files.
+//!
+//! This module parses custom Cedar syntax extensions that specify mandatory reviewers:
+//! ```cedar
+//! permit(action == "code:review", principal, resource)
+//!     when { resource.path.startsWith("service_a/") }
+//!     to ["alice", "bob"];
+//! ```
+
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::collections::{HashMap, HashSet};
+
+lazy_static! {
+    static ref RULE_PATTERN: Regex = Regex::new(
+        r#"(?s)permit\s*\([^)]*\)\s*when\s*\{\s*resource\.path\.startsWith\s*\(\s*"([^"]*)"\s*\)\s*\}\s*to\s*\[([^\]]+)\]"#
+    ).unwrap();
+    static ref REVIEWER_PATTERN: Regex = Regex::new(r#""([^"]+)""#).unwrap();
+}
+
+/// Represents a reviewer rule extracted from policy file
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReviewerRule {
+    /// Path pattern (e.g., "service_a/", "src/core/")
+    pub path_pattern: String,
+    /// List of required reviewers
+    pub reviewers: Vec<String>,
+}
+
+/// Parse policy content and extract reviewer rules
+///
+/// # Arguments
+/// * `policy_content` - The content of the .cedar/policies.cedar file
+///
+/// # Returns
+/// A vector of ReviewerRule extracted from the policy
+pub fn parse_reviewer_rules(policy_content: &str) -> Vec<ReviewerRule> {
+    let mut rules = Vec::new();
+
+    for cap in RULE_PATTERN.captures_iter(policy_content) {
+        let path_pattern = cap
+            .get(1)
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_default();
+        let reviewers_str = cap.get(2).map(|m| m.as_str()).unwrap_or_default();
+
+        // Parse reviewer list: "alice", "bob" -> vec!["alice", "bob"]
+        let reviewers: Vec<String> = REVIEWER_PATTERN
+            .captures_iter(reviewers_str)
+            .filter_map(|c| c.get(1).map(|m| m.as_str().to_string()))
+            .collect();
+
+        // Allow empty path_pattern (matches all files)
+        if !reviewers.is_empty() {
+            rules.push(ReviewerRule {
+                path_pattern,
+                reviewers,
+            });
+        }
+    }
+
+    rules
+}
+
+/// Find matching reviewers for a given file path
+///
+/// # Arguments
+/// * `rules` - List of reviewer rules
+/// * `file_path` - The file path to match against
+///
+/// # Returns
+/// A list of required reviewer usernames
+pub fn find_reviewers_for_path(rules: &[ReviewerRule], file_path: &str) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut reviewers = Vec::new();
+
+    // Normalize path: remove leading slash for consistent matching
+    let normalized_path = file_path.trim_start_matches('/');
+
+    for rule in rules {
+        let normalized_pattern = rule.path_pattern.trim_start_matches('/');
+
+        // Match if path starts with pattern, or pattern is empty (matches all)
+        if normalized_pattern.is_empty() || normalized_path.starts_with(normalized_pattern) {
+            for reviewer in &rule.reviewers {
+                if seen.insert(reviewer.clone()) {
+                    reviewers.push(reviewer.clone());
+                }
+            }
+        }
+    }
+
+    reviewers
+}
+
+/// Aggregate reviewers from multiple policy files with override semantics
+///
+/// For the same path_pattern, rules from child directories override parent directories.
+/// Different path_patterns are merged (accumulated).
+///
+/// # Arguments
+/// * `policy_contents` - List of (policy_path, content) tuples, from root to leaf
+/// * `target_path` - The file path to find reviewers for
+///
+/// # Returns
+/// Combined list of required reviewers after applying override rules
+pub fn aggregate_reviewers<P: AsRef<str>>(
+    policy_contents: &[(P, String)],
+    target_path: &str,
+) -> Vec<String> {
+    // Use HashMap to store reviewers by path_pattern
+    // Later entries (child directories) override earlier entries (parent directories)
+    let mut pattern_reviewers: HashMap<String, Vec<String>> = HashMap::new();
+
+    let normalized_target = target_path.trim_start_matches('/');
+
+    for (_, content) in policy_contents {
+        let rules = parse_reviewer_rules(content);
+
+        for rule in rules {
+            let normalized_pattern = rule.path_pattern.trim_start_matches('/');
+
+            // Check if this rule matches the target path
+            let matches =
+                normalized_pattern.is_empty() || normalized_target.starts_with(normalized_pattern);
+
+            if matches {
+                // Override: same path_pattern from child replaces parent
+                pattern_reviewers.insert(rule.path_pattern.clone(), rule.reviewers);
+            }
+        }
+    }
+
+    // Merge all reviewers from different patterns (deduplicated)
+    let mut seen = HashSet::new();
+    let mut all_reviewers = Vec::new();
+    for reviewers in pattern_reviewers.values() {
+        for reviewer in reviewers {
+            if seen.insert(reviewer.clone()) {
+                all_reviewers.push(reviewer.clone());
+            }
+        }
+    }
+
+    all_reviewers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Comprehensive test for reviewer_parser module
+    /// Run with: cargo test -p saturn test_reviewer_parser_comprehensive -- --nocapture
+    #[test]
+    fn test_reviewer_parser_comprehensive() {
+        println!("\n{}", "=".repeat(70));
+        println!("Cedar Reviewer Parser - Comprehensive Test");
+        println!("{}", "=".repeat(70));
+
+        // ========== 1. Policy Parsing ==========
+        println!("\n[1] Policy Parsing");
+        println!("{}", "-".repeat(50));
+
+        let policy = r#"
+permit(action == "code:review", principal, resource)
+    when { resource.path.startsWith("service_a/") }
+    to ["alice", "bob"];
+
+permit(action == "code:review", principal, resource)
+    when { resource.path.startsWith("core/") }
+    to ["charlie"];
+        "#;
+
+        println!("Input policy:\n{}", policy);
+        let rules = parse_reviewer_rules(policy);
+        println!("\nParsed rules:");
+        for (i, rule) in rules.iter().enumerate() {
+            println!(
+                "  [{}] pattern='{}' reviewers={:?}",
+                i, rule.path_pattern, rule.reviewers
+            );
+        }
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].path_pattern, "service_a/");
+        assert_eq!(rules[0].reviewers, vec!["alice", "bob"]);
+        assert_eq!(rules[1].path_pattern, "core/");
+        assert_eq!(rules[1].reviewers, vec!["charlie"]);
+        println!("✓ Policy parsing OK");
+
+        // ========== 2. Path Matching ==========
+        println!("\n[2] Path Matching");
+        println!("{}", "-".repeat(50));
+
+        let test_cases = vec![
+            ("service_a/src/main.rs", vec!["alice", "bob"]),
+            ("core/lib.rs", vec!["charlie"]),
+            ("other/file.rs", vec![]),
+        ];
+
+        for (path, expected) in test_cases {
+            let result = find_reviewers_for_path(&rules, path);
+            println!("  Path '{}' -> {:?}", path, result);
+            assert_eq!(
+                result,
+                expected.iter().map(|s| s.to_string()).collect::<Vec<_>>()
+            );
+        }
+        println!("✓ Path matching OK");
+
+        // ========== 3. Hierarchical Override (Same Pattern) ==========
+        println!("\n[3] Hierarchical Override - Same Pattern (Child Wins)");
+        println!("{}", "-".repeat(50));
+
+        let policies = vec![
+            (
+                "/repo".to_string(),
+                r#"permit(action == "code:review", principal, resource)
+                    when { resource.path.startsWith("service_a/") }
+                    to ["alice"];"#
+                    .to_string(),
+            ),
+            (
+                "/repo/service_a".to_string(),
+                r#"permit(action == "code:review", principal, resource)
+                    when { resource.path.startsWith("service_a/") }
+                    to ["bob", "charlie"];"#
+                    .to_string(),
+            ),
+        ];
+
+        println!("  Root policy: service_a/ -> [alice]");
+        println!("  Child policy: service_a/ -> [bob, charlie]");
+
+        let reviewers = aggregate_reviewers(&policies, "service_a/src/main.rs");
+        println!("  Result for 'service_a/src/main.rs': {:?}", reviewers);
+
+        assert!(
+            !reviewers.contains(&"alice".to_string()),
+            "alice should be overridden"
+        );
+        assert!(reviewers.contains(&"bob".to_string()));
+        assert!(reviewers.contains(&"charlie".to_string()));
+        println!("✓ Same pattern override OK (child wins)");
+
+        // ========== 4. Hierarchical Merge (Different Patterns) ==========
+        println!("\n[4] Hierarchical Merge - Different Patterns");
+        println!("{}", "-".repeat(50));
+
+        let policies = vec![
+            (
+                "/repo".to_string(),
+                r#"permit(action == "code:review", principal, resource)
+                    when { resource.path.startsWith("") }
+                    to ["root_reviewer"];"#
+                    .to_string(),
+            ),
+            (
+                "/repo/service_a".to_string(),
+                r#"permit(action == "code:review", principal, resource)
+                    when { resource.path.startsWith("service_a/") }
+                    to ["alice"];"#
+                    .to_string(),
+            ),
+        ];
+
+        println!("  Root policy: '' (global) -> [root_reviewer]");
+        println!("  Child policy: service_a/ -> [alice]");
+
+        let reviewers = aggregate_reviewers(&policies, "service_a/src/main.rs");
+        println!("  Result for 'service_a/src/main.rs': {:?}", reviewers);
+
+        assert!(reviewers.contains(&"root_reviewer".to_string()));
+        assert!(reviewers.contains(&"alice".to_string()));
+        assert_eq!(reviewers.len(), 2);
+        println!("✓ Different patterns merge OK");
+
+        // ========== 5. Complex Hierarchy ==========
+        println!("\n[5] Complex Hierarchy - Override + Merge");
+        println!("{}", "-".repeat(50));
+
+        let policies = vec![
+            (
+                "/repo".to_string(),
+                r#"
+                permit(action == "code:review", principal, resource)
+                    when { resource.path.startsWith("") }
+                    to ["global_owner"];
+                permit(action == "code:review", principal, resource)
+                    when { resource.path.startsWith("service_a/") }
+                    to ["old_service_owner"];
+                "#
+                .to_string(),
+            ),
+            (
+                "/repo/service_a".to_string(),
+                r#"permit(action == "code:review", principal, resource)
+                    when { resource.path.startsWith("service_a/") }
+                    to ["new_service_owner"];"#
+                    .to_string(),
+            ),
+        ];
+
+        println!("  Root policy:");
+        println!("    - '' (global) -> [global_owner]");
+        println!("    - service_a/ -> [old_service_owner]");
+        println!("  Child policy:");
+        println!("    - service_a/ -> [new_service_owner]");
+
+        let reviewers = aggregate_reviewers(&policies, "service_a/src/main.rs");
+        println!("  Result for 'service_a/src/main.rs': {:?}", reviewers);
+
+        assert!(reviewers.contains(&"global_owner".to_string()));
+        assert!(
+            !reviewers.contains(&"old_service_owner".to_string()),
+            "old should be overridden"
+        );
+        assert!(reviewers.contains(&"new_service_owner".to_string()));
+        assert_eq!(reviewers.len(), 2);
+        println!("✓ Complex hierarchy OK");
+
+        // ========== Summary ==========
+        println!("\n{}", "=".repeat(70));
+        println!("ALL TESTS PASSED!");
+        println!("{}", "=".repeat(70));
+        println!("\nTested features:");
+        println!("  - Parse 'to []' syntax from Cedar policy");
+        println!("  - Match file path to reviewer rules");
+        println!("  - Hierarchical override: same pattern, child wins");
+        println!("  - Hierarchical merge: different patterns accumulate");
+        println!();
+    }
+
+    /// Test edge cases in policy parsing
+    /// Run with: cargo test -p saturn test_policy_parsing_edge_cases -- --nocapture
+    #[test]
+    fn test_policy_parsing_edge_cases() {
+        println!("\n{}", "=".repeat(70));
+        println!("Policy Parsing Edge Cases");
+        println!("{}", "=".repeat(70));
+
+        // Test case 1: Empty policy file
+        println!("\n[1] Empty policy file");
+        let rules = parse_reviewer_rules("");
+        assert!(rules.is_empty());
+        println!("✓ Empty policy returns no rules");
+
+        // Test case 2: Policy with no reviewers
+        println!("\n[2] Policy with comments only");
+        let policy = r#"
+        // This is a comment
+        /* Multi-line
+           comment */
+        "#;
+        let rules = parse_reviewer_rules(policy);
+        assert!(rules.is_empty());
+        println!("✓ Comments-only policy returns no rules");
+
+        // Test case 3: Policy with single reviewer
+        println!("\n[3] Single reviewer");
+        let policy = r#"
+        permit(action == "code:review", principal, resource)
+            when { resource.path.startsWith("src/") }
+            to ["single_user"];
+        "#;
+        let rules = parse_reviewer_rules(policy);
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].reviewers, vec!["single_user"]);
+        println!("✓ Single reviewer parsed correctly");
+
+        // Test case 4: Policy with many reviewers
+        println!("\n[4] Many reviewers");
+        let policy = r#"
+        permit(action == "code:review", principal, resource)
+            when { resource.path.startsWith("critical/") }
+            to ["alice", "bob", "charlie", "david", "eve"];
+        "#;
+        let rules = parse_reviewer_rules(policy);
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].reviewers.len(), 5);
+        println!("✓ Many reviewers parsed correctly");
+
+        // Test case 5: Multiple policies in one file
+        println!("\n[5] Multiple policies in one file");
+        let policy = r#"
+        permit(action == "code:review", principal, resource)
+            when { resource.path.startsWith("frontend/") }
+            to ["frontend_lead"];
+        
+        permit(action == "code:review", principal, resource)
+            when { resource.path.startsWith("backend/") }
+            to ["backend_lead"];
+        
+        permit(action == "code:review", principal, resource)
+            when { resource.path.startsWith("infra/") }
+            to ["devops_lead", "sre_lead"];
+        "#;
+        let rules = parse_reviewer_rules(policy);
+        assert_eq!(rules.len(), 3);
+        println!("✓ Multiple policies parsed correctly");
+
+        // Test case 6: Global policy (empty path pattern)
+        println!("\n[6] Global policy (empty path)");
+        let policy = r#"
+        permit(action == "code:review", principal, resource)
+            when { resource.path.startsWith("") }
+            to ["global_owner"];
+        "#;
+        let rules = parse_reviewer_rules(policy);
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].path_pattern, "");
+        let reviewers = find_reviewers_for_path(&rules, "any/path/file.rs");
+        assert_eq!(reviewers, vec!["global_owner"]);
+        println!("✓ Global policy matches all paths");
+
+        println!("\n{}", "=".repeat(70));
+        println!("EDGE CASE TESTS PASSED!");
+        println!("{}", "=".repeat(70));
+    }
+
+    /// Test the complete flow: policy loading -> parsing -> reviewer assignment
+    /// Run with: cargo test -p saturn test_complete_reviewer_flow -- --nocapture
+    #[test]
+    fn test_complete_reviewer_flow() {
+        println!("\n{}", "=".repeat(70));
+        println!("Complete Reviewer Assignment Flow Test");
+        println!("{}", "=".repeat(70));
+
+        // Simulate a real-world scenario:
+        // Repository structure:
+        // /
+        // ├── .cedar/policies.cedar (global owner)
+        // ├── service_a/
+        // │   ├── .cedar/policies.cedar (service_a owners)
+        // │   └── src/
+        // │       └── core/
+        // │           └── .cedar/policies.cedar (core module owners)
+        // └── service_b/
+        //     └── .cedar/policies.cedar (service_b owners)
+
+        println!("\n[Scenario] Multi-level policy hierarchy");
+        println!("  Repository structure:");
+        println!("  /");
+        println!("  ├── .cedar/policies.cedar -> [global_owner]");
+        println!("  ├── service_a/");
+        println!("  │   ├── .cedar/policies.cedar -> [alice, bob]");
+        println!("  │   └── src/core/");
+        println!("  │       └── .cedar/policies.cedar -> [core_expert]");
+        println!("  └── service_b/");
+        println!("      └── .cedar/policies.cedar -> [charlie]");
+
+        // Simulate policy files content
+        let root_policy = r#"
+        permit(action == "code:review", principal, resource)
+            when { resource.path.startsWith("") }
+            to ["global_owner"];
+        "#
+        .to_string();
+
+        let service_a_policy = r#"
+        permit(action == "code:review", principal, resource)
+            when { resource.path.startsWith("service_a/") }
+            to ["alice", "bob"];
+        "#
+        .to_string();
+
+        let core_policy = r#"
+        permit(action == "code:review", principal, resource)
+            when { resource.path.startsWith("service_a/src/core/") }
+            to ["core_expert"];
+        "#
+        .to_string();
+
+        let service_b_policy = r#"
+        permit(action == "code:review", principal, resource)
+            when { resource.path.startsWith("service_b/") }
+            to ["charlie"];
+        "#
+        .to_string();
+
+        // Test case 1: CL in service_a/src/core/
+        println!("\n[1] CL path: service_a/src/core/main.rs");
+        let policies = vec![
+            ("/.cedar/policies.cedar".to_string(), root_policy.clone()),
+            (
+                "service_a/.cedar/policies.cedar".to_string(),
+                service_a_policy.clone(),
+            ),
+            (
+                "service_a/src/core/.cedar/policies.cedar".to_string(),
+                core_policy.clone(),
+            ),
+        ];
+        let reviewers = aggregate_reviewers(&policies, "service_a/src/core/main.rs");
+        println!("  Expected: global_owner + alice + bob + core_expert");
+        println!("  Actual: {:?}", reviewers);
+        assert!(reviewers.contains(&"global_owner".to_string()));
+        assert!(reviewers.contains(&"alice".to_string()));
+        assert!(reviewers.contains(&"bob".to_string()));
+        assert!(reviewers.contains(&"core_expert".to_string()));
+        println!("✓ All hierarchical reviewers included");
+
+        // Test case 2: CL in service_b/
+        println!("\n[2] CL path: service_b/handler.rs");
+        let policies = vec![
+            ("/.cedar/policies.cedar".to_string(), root_policy.clone()),
+            (
+                "service_b/.cedar/policies.cedar".to_string(),
+                service_b_policy.clone(),
+            ),
+        ];
+        let reviewers = aggregate_reviewers(&policies, "service_b/handler.rs");
+        println!("  Expected: global_owner + charlie");
+        println!("  Actual: {:?}", reviewers);
+        assert!(reviewers.contains(&"global_owner".to_string()));
+        assert!(reviewers.contains(&"charlie".to_string()));
+        assert!(!reviewers.contains(&"alice".to_string())); // service_a owner should not be included
+        println!("✓ Only relevant reviewers included");
+
+        // Test case 3: CL in root (no service-specific policy)
+        println!("\n[3] CL path: README.md (root level)");
+        let policies = vec![("/.cedar/policies.cedar".to_string(), root_policy.clone())];
+        let reviewers = aggregate_reviewers(&policies, "README.md");
+        println!("  Expected: global_owner only");
+        println!("  Actual: {:?}", reviewers);
+        assert_eq!(reviewers, vec!["global_owner"]);
+        println!("✓ Root-level CL gets global owner only");
+
+        println!("\n{}", "=".repeat(70));
+        println!("COMPLETE FLOW TESTS PASSED!");
+        println!("{}", "=".repeat(70));
+    }
+}


### PR DESCRIPTION
link #1704 

## 流程

### A. 创建 CL (新提交)

当用户首次 Push 代码时，系统自动收集策略并分配 Reviewer。

```
用户 git push
    ↓
MonoRepo::save_or_update_cl()
    ↓
检测是否新 CL (is_new_cl)
    ↓ (是，新 CL)
assign_system_reviewers()
    ↓
collect_policy_contents()  ← 从 CL 路径向上收集所有 .cedar/policies.cedar
    ↓
ReviewerService::assign_system_reviewers()
    ↓
aggregate_reviewers()  ← 解析并合并策略（子目录覆盖父目录同路径规则）
    ↓
存储到数据库 (system_required = true)
```

### B. 更新 CL (策略变更)

当用户更新现有 CL 且包含 `.cedar` 策略文件时，触发增量同步。

```
用户 git push (更新)
    ↓
MonoRepo::save_or_update_cl()
    ↓
检测是否新 CL (is_new_cl)
    ↓ (否，现有 CL)
resync_current_cl_reviewers_if_policy_changed()
    ↓
get_changed_files()  ← 获取本次提交变更的文件列表
    ↓
检测变更是否包含 .cedar 文件?
    ↓ (是)
ReviewerService::sync_system_reviewers()
    ↓
移除当前 CL 下所有 System Required Reviewers
    ↓
aggregate_reviewers()  ← 重新解析策略并计算新名单
    ↓
写入新 Reviewers
```



## 策略合并规则

**示例**：CL 修改 `service_a/core/main.rs`

| 策略文件位置                            | 规则内容                                              |
| --------------------------------------- | ----------------------------------------------------- |
| `/.cedar/policies.cedar`                | `"" -> [global_owner]`, `"service_a/" -> [old_alice]` |
| `/service_a/.cedar/policies.cedar`      | `"service_a/" -> [alice, bob]`                        |
| `/service_a/core/.cedar/policies.cedar` | `"service_a/core/" -> [core_expert]`                  |

**结果**：

- `global_owner` ← 来自根目录 `""` 规则
- `alice, bob` ← 来自 service_a 目录，**覆盖了** `old_alice`
- `core_expert` ← 来自 core 目录

**最终 Reviewers**：`[global_owner, alice, bob, core_expert]`



## TODO

在`monorepo`方法中，有一个逻辑是注释的，还没有实现

在当前`CL`被合并到主分支的时候再同步当前受到影响的`CL`的`reviewer`











