### PR TITLE
Fix/orion server build error

### DIFF
--- a/orion-server/Dockerfile
+++ b/orion-server/Dockerfile
@@ -1,5 +1,5 @@
 # ────── Stage 1: Build ──────
-FROM rust:1.88 as builder
+FROM rust:1.92-bookworm AS builder
 
 # 构建上下文中的父目录将作为 /app 挂载
 WORKDIR /app

--- a/orion-server/src/api.rs
+++ b/orion-server/src/api.rs
@@ -776,16 +776,18 @@ async fn process_message(
                         );
                     }
                 }
-                WSMessage::Lost => {
-                    if let Some(mut worker) = state.scheduler.workers.get_mut(current_worker_id) {
-                        worker.status = WorkerStatus::Lost
-                    }
-                }
                 _ => {}
             }
         }
         Message::Close(_) => {
             tracing::info!("Client {who} sent close message.");
+            if let Some(id) = worker_id.take()
+                && let Some(mut worker) = state.scheduler.workers.get_mut(&id)
+            {
+                worker.status = WorkerStatus::Lost;
+                tracing::info!("Worker {id} marked as Lost due to connection close");
+            }
+
             return ControlFlow::Break(());
         }
         _ => {}

--- a/orion-server/src/server.rs
+++ b/orion-server/src/server.rs
@@ -26,6 +26,8 @@ use crate::model::builds;
         api::task_output_handler,
         api::task_history_output_handler,
         api::tasks_handler,
+        api::get_orion_clients_info,
+        api::get_orion_client_status_by_id
     ),
     components(
         schemas(
@@ -33,8 +35,11 @@ use crate::model::builds;
             crate::scheduler::LogSegment,
             api::TaskStatusEnum,
             api::BuildDTO,
-            api::TaskInfoDTO
-
+            api::TaskInfoDTO,
+            api::OrionClientInfo,
+            api::OrionClientStatus,
+            api::CoreWorkerStatus,
+            api::OrionClientQuery
         )
     ),
     tags(

--- a/orion/src/ws.rs
+++ b/orion/src/ws.rs
@@ -32,8 +32,6 @@ pub enum WSMessage {
         orion_version: String,
     },
     Heartbeat,
-    // Sent by the client when its internal channel has closed (client-initiated disconnect)
-    Lost,
     // Sent when a task is in the build process and its execution phase changes.
     TaskPhaseUpdate {
         id: String,
@@ -169,13 +167,6 @@ async fn handle_connection(
                 }
             }
         }
-
-        // One of the critical tasks has terminated; the connection is lost.
-        let _ = ws_sender
-            .send(Message::Text(
-                serde_json::to_string(&WSMessage::Lost).unwrap().into(),
-            ))
-            .await;
     });
 
     let internal_tx_clone = internal_tx.clone();


### PR DESCRIPTION
## 问题：在构建 `orion-server` 的时候报错，判断为 `cedar` 版本升级导致的
<img width="900" height="489" alt="image" src="https://github.com/user-attachments/assets/499c2ddf-2792-46ed-ba66-b7fcdecfac4d" />

### 产生原因： https://github.com/web3infra-foundation/mega/pull/1732 中，在 `orion-server` 中 引入 `common` 包导致（原来的 `orion-server` 没有 `cedar`，但是 `common` 有）
<img width="1280" height="737" alt="image" src="https://github.com/user-attachments/assets/afd7c21f-df83-4a5e-900a-735412a7a993" />

### 解决方案
1. 升级 rust，`orion-server/Dockerfile` 中
<img width="948" height="171" alt="image" src="https://github.com/user-attachments/assets/c31ed002-714d-46f2-ab3f-60e5680e47e4" />

2. 同时修复了https://github.com/web3infra-foundation/mega/pull/1732 和
https://github.com/web3infra-foundation/mega/issues/1706 的一点小问题
- 放弃了 Orion 中 Lost 消息的发送，集中到 orion-server 进行处理
- 完善 openApi 结构体文档