### PR TITLE
fix: swagger doc missing

### DIFF
--- a/orion-server/src/scheduler.rs
+++ b/orion-server/src/scheduler.rs
@@ -1,3 +1,4 @@
+use crate::api::CoreWorkerStatus;
 use crate::log::log_service::LogService;
 use crate::model::builds;
 use chrono::FixedOffset;
@@ -139,7 +140,7 @@ pub struct BuildInfo {
 }
 
 /// Status of a worker node
-#[derive(Debug, Clone, Serialize, ToSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema, PartialEq, Eq)]
 pub enum WorkerStatus {
     Idle,
     Busy {
@@ -150,6 +151,17 @@ pub enum WorkerStatus {
     },
     Error(String), // Contains fail message
     Lost,          // Heartbeat timeout
+}
+
+impl WorkerStatus {
+    pub fn status_type(&self) -> CoreWorkerStatus {
+        match self {
+            WorkerStatus::Idle => CoreWorkerStatus::Idle,
+            WorkerStatus::Busy { .. } => CoreWorkerStatus::Busy,
+            WorkerStatus::Error(_) => CoreWorkerStatus::Error,
+            WorkerStatus::Lost => CoreWorkerStatus::Lost,
+        }
+    }
 }
 
 /// Information about a connected worker

--- a/orion-server/src/server.rs
+++ b/orion-server/src/server.rs
@@ -6,6 +6,7 @@ use axum::Router;
 use axum::routing::get;
 use chrono::{FixedOffset, Utc};
 use http::{HeaderValue, Method};
+use orion::ws::TaskPhase;
 use sea_orm::{ActiveValue::Set, ColumnTrait, Database, EntityTrait, QueryFilter};
 use tower::ServiceBuilder;
 use tower_http::cors::CorsLayer;
@@ -39,7 +40,8 @@ use crate::model::builds;
             api::OrionClientInfo,
             api::OrionClientStatus,
             api::CoreWorkerStatus,
-            api::OrionClientQuery
+            api::OrionClientQuery,
+            TaskPhase,
         )
     ),
     tags(

--- a/orion/src/ws.rs
+++ b/orion/src/ws.rs
@@ -15,7 +15,7 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 /// Task phase when in buck2 build
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
 pub enum TaskPhase {
     DownloadingSource,
     RunningBuild,


### PR DESCRIPTION
## 修复 Orion 接口文档中 `get_orion_clients_info` 和 `get_orion_client_status_by_id` 接口 不存在问题，同时检索条件添加 `status`

issue： https://github.com/web3infra-foundation/mega/issues/1706
### 原因 接口和 handler 没被生成进文档，是因为：这两个接口函数不是 pub 😂
- 接口函数加上pub即可
- 添加检索条件 `status`，注意 `WokerStatus` 中的 `Busy` 包括两个阶段状态（DownloadingSource， RunningBuild），注意区分。并对接口请求形式做出一定调整。

请求 `get_orion_clients_info` 前端传递数据
```json
{
  "pagination": {
    "page": 1,
    "per_page": 20
  },
  "additional": {
    "hostname": "node01",
    "status": "Busy", // 本次pr新增
    "phase": "DownloadingSource"  // 本次pr新增
  }
}
```