### PR TITLE
refactor(buck): rename session_id to cl_link in Buck Upload API

### DIFF
--- a/ceres/src/model/buck.rs
+++ b/ceres/src/model/buck.rs
@@ -15,8 +15,8 @@ pub struct CreateSessionPayload {
 /// Response for session creation
 #[derive(Debug, Serialize, ToSchema)]
 pub struct SessionResponse {
-    /// Unique session identifier (8 characters)
-    pub session_id: String,
+    /// CL link (8-character alphanumeric identifier, same as session_id)
+    pub cl_link: String,
     /// Session expiration time (RFC3339 format)
     pub expires_at: String,
     /// Maximum file size in bytes

--- a/mono/tests/buck_service_tests.rs
+++ b/mono/tests/buck_service_tests.rs
@@ -227,7 +227,7 @@ async fn test_create_session_success() {
     // Verify session was created
     let session = storage
         .buck_storage()
-        .get_session(&response.session_id)
+        .get_session(&response.cl_link)
         .await
         .unwrap()
         .expect("Session should exist");
@@ -240,7 +240,7 @@ async fn test_create_session_success() {
     // Verify CL was created
     let cl = storage
         .cl_storage()
-        .get_cl(&response.session_id)
+        .get_cl(&response.cl_link)
         .await
         .unwrap();
     assert!(cl.is_some(), "Draft CL should be created");
@@ -289,7 +289,7 @@ async fn test_create_session_expires_at_calculation() {
     // Verify it matches session's expires_at
     let session = storage
         .buck_storage()
-        .get_session(&response.session_id)
+        .get_session(&response.cl_link)
         .await
         .unwrap()
         .unwrap();


### PR DESCRIPTION
- Update API path parameters from session_id to cl_link
- Update SessionResponse field name from session_id to cl_link
- Synchronize parameter names across router, service, and API layers
- Update test cases to use cl_link
- Maintain path structure: /session/{cl_link}/