### PR TITLE
fix: Simplify the parsedDiffs function by removing the complex logic for file format and path extraction.

### DIFF
--- a/moon/apps/web/components/CodeView/BlobView/BlobEditor.tsx
+++ b/moon/apps/web/components/CodeView/BlobView/BlobEditor.tsx
@@ -12,7 +12,7 @@ import { Dialog } from '@gitmono/ui/Dialog'
 import { useDiffPreview } from '@/hooks/useDiffPreview'
 import { useGetCurrentUser } from '@/hooks/useGetCurrentUser'
 import { useUpdateBlob } from '@/hooks/useUpdateBlob'
-import { getLangFromFileName } from '@/utils/getLanguageDetection'
+import { getLangFromFileNameToDiff } from '@/utils/getLanguageDetection'
 
 interface BlobEditorProps {
   fileContent: string
@@ -64,7 +64,7 @@ export default function BlobEditor({ fileContent, filePath, fileName, onCancel }
     return dir ? `${dir}/${editedFileName}` : editedFileName
   }, [pathSegments, editedFileName])
 
-  const detectedLanguage = useMemo(() => getLangFromFileName(editedFileName), [editedFileName])
+  const detectedLanguage = useMemo(() => getLangFromFileNameToDiff(editedFileName), [editedFileName])
 
   const handlePreviewClick = useCallback(async () => {
     setViewMode('preview')
@@ -83,7 +83,7 @@ export default function BlobEditor({ fileContent, filePath, fileName, onCancel }
         setDiffResult(result)
 
         if (result?.data?.data) {
-          const diff = new DiffFile('', '', '', '', [result.data.data], detectedLanguage || 'plaintext')
+          const diff = new DiffFile('', '', '', '', [result.data.data], detectedLanguage)
 
           diff.init()
           diff.buildSplitDiffLines()

--- a/moon/apps/web/components/CodeView/BlobView/CodeContent.tsx
+++ b/moon/apps/web/components/CodeView/BlobView/CodeContent.tsx
@@ -486,9 +486,10 @@ const CodeContent = ({
             return (
               <div
                 key={`block-${blockIndex}`}
+                data-index={blockIndex}
                 className={`border-x border-gray-200 transition-colors duration-150 ${
                   isFirstBlock ? 'border-t' : ''
-                } ${isLastBlock ? 'rounded-b-lg border-b' : ''}`}
+                } ${isLastBlock ? 'rounded-b-lg border-b' : 'border-b'}`}
               >
                 <div className='flex min-w-0'>
                   <div className='flex w-1 flex-shrink-0 items-center'>

--- a/moon/apps/web/components/DiffView/parsedDiffs.ts
+++ b/moon/apps/web/components/DiffView/parsedDiffs.ts
@@ -9,16 +9,20 @@ export function parsedDiffs(diffText: DiffItem[]): { path: string; lang: string;
   if (diffText.length < 1) return []
 
   return diffText.map((block) => {
+    const isBinary = /Binary files.*differ/.test(block.data)
+
     const lang = getLangFromFileNameToDiff(block.path)
-
-    const isBinary = block.data.includes('Binary files differ')
-
-    const isEmptyDiff = !block.data.includes('@@')
 
     let diff = block.data
 
-    if (isEmptyDiff) {
-      diff = 'EMPTY_DIFF_MARKER'
+    if (isBinary) {
+      /* empty */
+    } else {
+      const isEmptyDiff = !block.data.includes('@@')
+
+      if (isEmptyDiff) {
+        diff = 'EMPTY_DIFF_MARKER'
+      }
     }
 
     if (!diff.endsWith('\n')) {

--- a/moon/apps/web/components/DiffView/parsedDiffs.ts
+++ b/moon/apps/web/components/DiffView/parsedDiffs.ts
@@ -9,47 +9,26 @@ export function parsedDiffs(diffText: DiffItem[]): { path: string; lang: string;
   if (diffText.length < 1) return []
 
   return diffText.map((block) => {
-    let path = ''
+    const lang = getLangFromFileNameToDiff(block.path)
 
-    const diffGitMatch = block.data.match(/^diff --git a\/[^\s]+ b\/([^\s]+)/m)
+    const isBinary = block.data.includes('Binary files differ')
 
-    if (diffGitMatch) {
-      const originalPath = diffGitMatch[1]?.trim()
-      const newPath = diffGitMatch[2]?.trim()
+    const isEmptyDiff = !block.data.includes('@@')
 
-      if (newPath && newPath !== '/dev/null') {
-        path = newPath
-      } else {
-        path = originalPath
-      }
+    let diff = block.data
+
+    if (isEmptyDiff) {
+      diff = 'EMPTY_DIFF_MARKER'
     }
 
-    if (getLangFromFileNameToDiff(path) === 'binary') {
-      return {
-        path,
-        lang: getLangFromFileNameToDiff(path),
-        diff: block.data
-      }
-    }
-
-    let diffWithHeader = block.data
-    const headerRegex = /^(diff|index|---|\+\+\+|new file mode|@@)/
-    const hunkContent = block.data.split('\n').filter((line) => !headerRegex.test(line.trim()))
-
-    const isEmptyHunk = hunkContent.every((line) => line.trim() === '')
-
-    if (!block.data.includes('@@') || isEmptyHunk) {
-      diffWithHeader = 'EMPTY_DIFF_MARKER'
-    }
-
-    if (!diffWithHeader.endsWith('\n')) {
-      diffWithHeader += '\n'
+    if (!diff.endsWith('\n')) {
+      diff += '\n'
     }
 
     return {
       path: block.path,
-      lang: getLangFromFileNameToDiff(path),
-      diff: diffWithHeader
+      lang: isBinary ? 'binary' : lang,
+      diff
     }
   })
 }

--- a/moon/apps/web/utils/getLanguageDetection.ts
+++ b/moon/apps/web/utils/getLanguageDetection.ts
@@ -190,7 +190,7 @@ export function getLangFromFileName(fileName: string): string {
 }
 
 export function getLangFromFileNameToDiff(fileName: string): string {
-  if (!fileName) return 'binary'
+  if (!fileName) return 'plaintext'
   const lowerFileName = fileName.toLowerCase()
   const baseName = lowerFileName.split('/').pop() || ''
 
@@ -209,8 +209,8 @@ export function getLangFromFileNameToDiff(fileName: string): string {
   if (lastPart) {
     const extension = lastPart[0]
 
-    return LANGUAGE_MAP[extension] ?? 'binary'
+    return LANGUAGE_MAP[extension] ?? 'plaintext'
   }
 
-  return 'binary'
+  return 'plaintext'
 }


### PR DESCRIPTION
…xtraction logic.

 - Remove the complex logic for extracting paths from diff text and directly use block.path.
 - Identify binary files by detecting "Binary files differ" in the diff text.