### PR TITLE
Upgrade and unify git-internal dependency across workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 default-members = ["mono", "orion", "orion-server"]
 resolver = "1"
-exclude = ["scorpio"]
+
 
 [workspace.dependencies]
 mono = { path = "mono" }
@@ -31,7 +31,7 @@ orion = { path = "orion" }
 bellatrix = { path = "orion-server/bellatrix" }
 context = { path = "context" }
 
-git-internal = "0.3.0"
+git-internal = "0.4.0"
 libvault-core = "0.1.0"
 
 #====

--- a/ceres/src/api_service/blob_ops.rs
+++ b/ceres/src/api_service/blob_ops.rs
@@ -42,7 +42,7 @@ pub async fn get_file_blob_id<T: ApiHandler + ?Sized>(
 /// * `refs` - Optional commit hash or ref name
 ///
 /// # Returns
-/// HashMap mapping file paths to their blob IDs (as ObjectHash)
+/// HashMap mapping file paths to ObjectHash blob IDs
 /// Files not found will not be in the result (use contains_key to check)
 pub async fn get_files_blob_ids<T: ApiHandler + ?Sized>(
     handler: &T,

--- a/ceres/src/api_service/buck_tree_builder.rs
+++ b/ceres/src/api_service/buck_tree_builder.rs
@@ -1349,7 +1349,7 @@ mod tests {
     fn test_valid_sha1_hashes() {
         let valid_hashes = vec![
             "sha1:da39a3ee5e6b4b0d3255bfef95601890afd80709", // empty file
-            "ObjectHash:da39a3ee5e6b4b0d3255bfef95601890afd80709", // uppercase algorithm (normalized)
+            "SHA1:da39a3ee5e6b4b0d3255bfef95601890afd80709", // uppercase algorithm (normalized)
             "Sha1:da39a3ee5e6b4b0d3255bfef95601890afd80709", // mixed case algorithm (normalized)
             "sha1:356a192b7913b04c54574d18c28d46e6395428ab", // "1"
             "sha1:0000000000000000000000000000000000000000", // all zeros

--- a/ceres/src/api_service/buck_tree_builder.rs
+++ b/ceres/src/api_service/buck_tree_builder.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use common::errors::MegaError;
-use git_internal::hash::SHA1;
+use git_internal::hash::ObjectHash;
 use git_internal::internal::metadata::EntryMeta;
 use git_internal::internal::object::commit::Commit;
 use git_internal::internal::object::tree::{Tree, TreeItem, TreeItemMode};
@@ -26,7 +26,7 @@ pub struct TreeBuildResult {
     /// All new trees that need to be saved (including intermediate directories)
     pub new_trees: Vec<Tree>,
     /// The final tree hash (same as root_tree.id)
-    pub tree_hash: SHA1,
+    pub tree_hash: ObjectHash,
 }
 
 /// Result of building a complete commit
@@ -178,7 +178,7 @@ impl BuckCommitBuilder {
             .await?;
 
         // Create commit with the new tree
-        let parent_sha = SHA1::from_str(base_commit_hash)
+        let parent_sha = ObjectHash::from_str(base_commit_hash)
             .map_err(|e| MegaError::Other(format!("Invalid parent hash: {}", e)))?;
 
         let commit = Commit::from_tree_id(tree_result.tree_hash, vec![parent_sha], message);
@@ -441,9 +441,9 @@ impl BuckCommitBuilder {
     /// This is only used in memory during tree building.
     /// The actual Git tree object will be created when items are added.
     fn empty_tree() -> Tree {
-        // Create a valid empty tree to get the correct SHA1 hash
+        // Create a valid empty tree to get the correct ObjectHash hash
         Tree::from_tree_items(vec![]).unwrap_or(Tree {
-            id: SHA1::default(),
+            id: ObjectHash::default(),
             tree_items: vec![],
         })
     }
@@ -682,7 +682,7 @@ mod tests {
     #[test]
     fn test_nested_directory_tree_building() {
         // Setup: Create a file change for a/b/c.txt
-        let blob_hash = "da39a3ee5e6b4b0d3255bfef95601890afd80709"; // SHA1 of empty file
+        let blob_hash = "da39a3ee5e6b4b0d3255bfef95601890afd80709"; // ObjectHash of empty file
         let file = FileChange::new(
             "a/b/c.txt".to_string(),
             format!("sha1:{}", blob_hash),
@@ -855,7 +855,7 @@ mod tests {
         // Create a fake child tree for "src" directory
         let src_tree = Tree::from_tree_items(vec![TreeItem {
             mode: TreeItemMode::Blob,
-            id: SHA1::from_str("da39a3ee5e6b4b0d3255bfef95601890afd80709").unwrap(),
+            id: ObjectHash::from_str("da39a3ee5e6b4b0d3255bfef95601890afd80709").unwrap(),
             name: "main.rs".to_string(),
         }])
         .unwrap();
@@ -1342,14 +1342,14 @@ mod tests {
         }
     }
 
-    /// Test that valid SHA1 hashes with correct format are accepted.
+    /// Test that valid ObjectHash hashes with correct format are accepted.
     ///
     /// All hashes are normalized to lowercase per Git convention.
     #[test]
     fn test_valid_sha1_hashes() {
         let valid_hashes = vec![
             "sha1:da39a3ee5e6b4b0d3255bfef95601890afd80709", // empty file
-            "SHA1:da39a3ee5e6b4b0d3255bfef95601890afd80709", // uppercase algorithm (normalized)
+            "ObjectHash:da39a3ee5e6b4b0d3255bfef95601890afd80709", // uppercase algorithm (normalized)
             "Sha1:da39a3ee5e6b4b0d3255bfef95601890afd80709", // mixed case algorithm (normalized)
             "sha1:356a192b7913b04c54574d18c28d46e6395428ab", // "1"
             "sha1:0000000000000000000000000000000000000000", // all zeros
@@ -1747,7 +1747,8 @@ mod tests {
         let builder = BuckCommitBuilder::new(storage.mono_storage());
 
         // Create a tree with a subdirectory "config"
-        let config_tree_hash = SHA1::from_str("da39a3ee5e6b4b0d3255bfef95601890afd80709").unwrap();
+        let config_tree_hash =
+            ObjectHash::from_str("da39a3ee5e6b4b0d3255bfef95601890afd80709").unwrap();
         let existing_tree = Tree::from_tree_items(vec![TreeItem {
             mode: TreeItemMode::Tree,
             id: config_tree_hash,
@@ -1785,11 +1786,11 @@ mod tests {
     /// Test Git Sorting Rules
     #[test]
     fn test_git_sort_order() {
-        use git_internal::hash::SHA1;
+        use git_internal::hash::ObjectHash;
         use std::str::FromStr;
 
         // Setup items
-        let blob_hash = SHA1::from_str("da39a3ee5e6b4b0d3255bfef95601890afd80709").unwrap();
+        let blob_hash = ObjectHash::from_str("da39a3ee5e6b4b0d3255bfef95601890afd80709").unwrap();
 
         // According to Git rules:
         // "foo" (directory) -> implicitly "foo/"

--- a/ceres/src/api_service/buck_tree_builder.rs
+++ b/ceres/src/api_service/buck_tree_builder.rs
@@ -441,7 +441,7 @@ impl BuckCommitBuilder {
     /// This is only used in memory during tree building.
     /// The actual Git tree object will be created when items are added.
     fn empty_tree() -> Tree {
-        // Create a valid empty tree to get the correct ObjectHash hash
+        // Create a valid empty tree to get the correct ObjectHash
         Tree::from_tree_items(vec![]).unwrap_or(Tree {
             id: ObjectHash::default(),
             tree_items: vec![],
@@ -682,7 +682,7 @@ mod tests {
     #[test]
     fn test_nested_directory_tree_building() {
         // Setup: Create a file change for a/b/c.txt
-        let blob_hash = "da39a3ee5e6b4b0d3255bfef95601890afd80709"; // ObjectHash of empty file
+        let blob_hash = "da39a3ee5e6b4b0d3255bfef95601890afd80709"; // SHA-1 hash of empty file
         let file = FileChange::new(
             "a/b/c.txt".to_string(),
             format!("sha1:{}", blob_hash),
@@ -1342,7 +1342,7 @@ mod tests {
         }
     }
 
-    /// Test that valid ObjectHash hashes with correct format are accepted.
+    /// Test that valid ObjectHash values with correct format are accepted.
     ///
     /// All hashes are normalized to lowercase per Git convention.
     #[test]

--- a/ceres/src/api_service/cache.rs
+++ b/ceres/src/api_service/cache.rs
@@ -4,7 +4,7 @@ use redis::{AsyncCommands, aio::ConnectionManager};
 
 use common::errors::MegaError;
 use git_internal::{
-    hash::SHA1,
+    hash::ObjectHash,
     internal::object::{commit::Commit, tree::Tree},
 };
 
@@ -17,9 +17,13 @@ pub struct GitObjectCache {
 const DEFAULT_EXPIRY_SECONDS: u64 = 60 * 60 * 24 * 7; // 7 days
 
 impl GitObjectCache {
-    pub async fn get_tree<F, Fut>(&self, oid: SHA1, fetch_tree: F) -> Result<Arc<Tree>, MegaError>
+    pub async fn get_tree<F, Fut>(
+        &self,
+        oid: ObjectHash,
+        fetch_tree: F,
+    ) -> Result<Arc<Tree>, MegaError>
     where
-        F: Fn(SHA1) -> Fut,
+        F: Fn(ObjectHash) -> Fut,
         Fut: Future<Output = Result<Tree, MegaError>>,
     {
         let key = format!("{}:tree:{}", self.prefix, oid);
@@ -43,11 +47,11 @@ impl GitObjectCache {
 
     pub async fn get_commit<F, Fut>(
         &self,
-        oid: SHA1,
+        oid: ObjectHash,
         fetch_commit: F,
     ) -> Result<Arc<Commit>, MegaError>
     where
-        F: Fn(SHA1) -> Fut,
+        F: Fn(ObjectHash) -> Fut,
         Fut: Future<Output = Result<Commit, MegaError>>,
     {
         let mut conn = self.connection.clone();

--- a/ceres/src/api_service/commit_ops.rs
+++ b/ceres/src/api_service/commit_ops.rs
@@ -14,7 +14,7 @@ use crate::model::change_list::MuiTreeNode;
 use crate::model::commit::{CommitFilesChangedPage, CommitSummary, GpgStatus};
 use crate::model::git::{CommitBindingInfo, LatestCommitInfo};
 use common::model::{CommonPage, DiffItem, Pagination};
-use git_internal::hash::SHA1;
+use git_internal::hash::ObjectHash;
 use redis::AsyncCommands;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
@@ -301,7 +301,7 @@ async fn compute_path_hash<T: ApiHandler + ?Sized>(
     handler: &T,
     commit: &Commit,
     path: &PathBuf,
-) -> Result<Option<SHA1>, GitError> {
+) -> Result<Option<ObjectHash>, GitError> {
     let tree = handler
         .object_cache()
         .get_tree(commit.tree_id, |tree_id| async move {
@@ -346,7 +346,7 @@ pub async fn traverse_history_commits<T: ApiHandler + ?Sized>(
     let start = resolve_start_commit(handler, start_refs).await?;
 
     // BFS to collect all reachable commits (avoid missing merge histories)
-    let mut visited: HashSet<SHA1> = HashSet::new();
+    let mut visited: HashSet<ObjectHash> = HashSet::new();
     let mut queue: VecDeque<Commit> = VecDeque::new();
     let mut all: Vec<Commit> = Vec::new();
     queue.push_back((*start).clone());
@@ -448,18 +448,18 @@ pub async fn traverse_history_commits<T: ApiHandler + ?Sized>(
     Ok(result)
 }
 
-/// Collect all blobs (path -> SHA1) under a commit tree
+/// Collect all blobs (path -> ObjectHash) under a commit tree
 async fn collect_commit_blobs<T: ApiHandler + ?Sized>(
     handler: &T,
     commit: &Commit,
-) -> Result<Vec<(PathBuf, SHA1)>, GitError> {
+) -> Result<Vec<(PathBuf, ObjectHash)>, GitError> {
     // Load the root tree for this commit and traverse it
     let root_tree = handler
         .get_tree_by_hash(&commit.tree_id.to_string())
         .await?;
 
     // Generic DFS traversal using handler.get_tree_by_hash for child trees
-    let mut result: Vec<(PathBuf, SHA1)> = Vec::new();
+    let mut result: Vec<(PathBuf, ObjectHash)> = Vec::new();
     let mut stack: Vec<(PathBuf, git_internal::internal::object::tree::Tree)> =
         vec![(PathBuf::new(), root_tree)];
     while let Some((base, tree)) = stack.pop() {
@@ -615,12 +615,12 @@ async fn compute_changed_paths<T: ApiHandler + ?Sized>(
     commit: &Commit,
 ) -> Result<Vec<String>, GitError> {
     let new_blobs = collect_commit_blobs(handler, commit).await?;
-    let new_map: HashMap<String, SHA1> = new_blobs
+    let new_map: HashMap<String, ObjectHash> = new_blobs
         .into_iter()
         .map(|(path, hash)| (pathbuf_to_string(&path), hash))
         .collect();
 
-    let mut parent_maps: Vec<HashMap<String, SHA1>> = Vec::new();
+    let mut parent_maps: Vec<HashMap<String, ObjectHash>> = Vec::new();
     for &pid in &commit.parent_commit_ids {
         let parent = handler.get_commit_by_hash(&pid.to_string()).await?;
         let blobs = collect_commit_blobs(handler, &parent).await?;
@@ -683,8 +683,8 @@ async fn compute_commit_diff_items<T: ApiHandler + ?Sized>(
     filter_paths: Option<&[String]>,
 ) -> Result<Vec<DiffItem>, GitError> {
     let new_blobs = collect_commit_blobs(handler, commit).await?;
-    let mut all_hashes: HashSet<SHA1> = new_blobs.iter().map(|(_, hash)| *hash).collect();
-    let mut parent_blobs_set: Vec<Vec<(PathBuf, SHA1)>> = Vec::new();
+    let mut all_hashes: HashSet<ObjectHash> = new_blobs.iter().map(|(_, hash)| *hash).collect();
+    let mut parent_blobs_set: Vec<Vec<(PathBuf, ObjectHash)>> = Vec::new();
 
     for &pid in &commit.parent_commit_ids {
         let parent = handler.get_commit_by_hash(&pid.to_string()).await?;
@@ -696,7 +696,7 @@ async fn compute_commit_diff_items<T: ApiHandler + ?Sized>(
     }
 
     let ctx = handler.get_context();
-    let mut blob_cache: HashMap<SHA1, Vec<u8>> = HashMap::new();
+    let mut blob_cache: HashMap<ObjectHash, Vec<u8>> = HashMap::new();
     for hash in &all_hashes {
         match ctx.git_service.get_object_as_bytes(&hash.to_string()).await {
             Ok(blob) => {
@@ -706,7 +706,7 @@ async fn compute_commit_diff_items<T: ApiHandler + ?Sized>(
         }
     }
 
-    let read_content = |file: &PathBuf, hash: &SHA1| -> Vec<u8> {
+    let read_content = |file: &PathBuf, hash: &ObjectHash| -> Vec<u8> {
         blob_cache.get(hash).cloned().unwrap_or_else(|| {
             tracing::warn!("Missing blob for {:?} {}", file, hash);
             Vec::new()
@@ -719,7 +719,7 @@ async fn compute_commit_diff_items<T: ApiHandler + ?Sized>(
     };
 
     let diff_results: Vec<git_internal::diff::DiffItem> = if parent_blobs_set.is_empty() {
-        let empty: Vec<(PathBuf, SHA1)> = Vec::new();
+        let empty: Vec<(PathBuf, ObjectHash)> = Vec::new();
         git_internal::diff::Diff::diff(empty, new_blobs, filters, read_content)
     } else {
         let mut combined: HashMap<String, git_internal::diff::DiffItem> = HashMap::new();

--- a/ceres/src/api_service/commit_ops.rs
+++ b/ceres/src/api_service/commit_ops.rs
@@ -448,7 +448,7 @@ pub async fn traverse_history_commits<T: ApiHandler + ?Sized>(
     Ok(result)
 }
 
-/// Collect all blobs (path -> ObjectHash) under a commit tree
+/// Collect all blobs as (path, ObjectHash) pairs under a commit tree
 async fn collect_commit_blobs<T: ApiHandler + ?Sized>(
     handler: &T,
     commit: &Commit,

--- a/ceres/src/api_service/import_api_service.rs
+++ b/ceres/src/api_service/import_api_service.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use callisto::{git_tag, import_refs};
 use common::errors::MegaError;
 use git_internal::errors::GitError;
-use git_internal::hash::SHA1;
+use git_internal::hash::ObjectHash;
 use git_internal::internal::metadata::{EntryMeta, MetaAttached};
 use git_internal::internal::object::commit::Commit;
 use git_internal::internal::object::tree::{Tree, TreeItem};
@@ -422,7 +422,7 @@ impl ApiHandler for ImportApiService {
                 .await
                 .map_err(|e| GitError::CustomError(e.to_string()))?
                 .ok_or(GitError::InvalidCommitObject)?;
-            let parent_id = SHA1::from_str(&current_commit.commit_id).unwrap();
+            let parent_id = ObjectHash::from_str(&current_commit.commit_id).unwrap();
 
             let new_commit =
                 Commit::from_tree_id(new_root_id, vec![parent_id], &payload.commit_message);
@@ -588,7 +588,7 @@ impl ImportApiService {
         let tag_target = target
             .as_ref()
             .ok_or(GitError::InvalidCommitObject)
-            .and_then(|t| SHA1::from_str(t).map_err(|_| GitError::InvalidCommitObject))?;
+            .and_then(|t| ObjectHash::from_str(t).map_err(|_| GitError::InvalidCommitObject))?;
         let git_internal_tag = git_internal::internal::object::tag::Tag::new(
             tag_target,
             git_internal::internal::object::types::ObjectType::Commit,
@@ -667,7 +667,7 @@ impl ImportApiService {
         &self,
         tree: Arc<Tree>,
         name: &str,
-        target_hash: SHA1,
+        target_hash: ObjectHash,
     ) -> Result<Tree, GitError> {
         let index = tree
             .tree_items
@@ -684,8 +684,8 @@ impl ImportApiService {
         &self,
         mut path: PathBuf,
         mut update_chain: Vec<Arc<Tree>>,
-        mut updated_tree_hash: SHA1,
-    ) -> Result<(Vec<Tree>, SHA1), GitError> {
+        mut updated_tree_hash: ObjectHash,
+    ) -> Result<(Vec<Tree>, ObjectHash), GitError> {
         let mut updated_trees = Vec::new();
         while let Some(tree) = update_chain.pop() {
             let cloned_path = path.clone();

--- a/ceres/src/model/buck.rs
+++ b/ceres/src/model/buck.rs
@@ -48,7 +48,7 @@ pub struct ManifestFile {
     pub hash: String,
 }
 
-/// Parse and validate SHA1 hash in "sha1:HEXSTRING" format
+/// Parse and validate ObjectHash hash in "sha1:HEXSTRING" format
 ///
 /// This is a shared helper function used by both ManifestFile and FileChange.
 /// It normalizes the hash to lowercase for consistency with Git conventions.
@@ -58,13 +58,13 @@ pub struct ManifestFile {
 /// * `field_name` - The name of the field (for error messages)
 ///
 /// # Returns
-/// The parsed SHA1 hash or an error if format is invalid
+/// The parsed ObjectHash hash or an error if format is invalid
 pub fn parse_sha1_hash(
     input: &str,
     field_name: &str,
-) -> Result<git_internal::hash::SHA1, common::errors::MegaError> {
+) -> Result<git_internal::hash::ObjectHash, common::errors::MegaError> {
     use common::errors::MegaError;
-    use git_internal::hash::SHA1;
+    use git_internal::hash::ObjectHash;
     use std::str::FromStr;
 
     let parts: Vec<&str> = input.splitn(2, ':').collect();
@@ -80,9 +80,9 @@ pub fn parse_sha1_hash(
     let hash_hex = parts[1].to_lowercase(); // Normalize to lowercase (Git convention)
 
     match algorithm.as_str() {
-        "sha1" => SHA1::from_str(&hash_hex).map_err(|e| {
+        "sha1" => ObjectHash::from_str(&hash_hex).map_err(|e| {
             MegaError::Other(format!(
-                "Invalid SHA1 hash in {}: '{}', error: {}",
+                "Invalid ObjectHash hash in {}: '{}', error: {}",
                 field_name, hash_hex, e
             ))
         }),
@@ -97,8 +97,8 @@ impl ManifestFile {
     /// Parse and validate hash format
     ///
     /// Expects format: "sha1:HEXSTRING" (case-insensitive, normalized to lowercase)
-    /// Returns the parsed SHA1 hash or an error if format is invalid
-    pub fn parse_hash(&self) -> Result<git_internal::hash::SHA1, common::errors::MegaError> {
+    /// Returns the parsed ObjectHash hash or an error if format is invalid
+    pub fn parse_hash(&self) -> Result<git_internal::hash::ObjectHash, common::errors::MegaError> {
         parse_sha1_hash(&self.hash, "hash field")
     }
 }
@@ -179,7 +179,7 @@ pub struct CompleteResponse {
 pub struct FileChange {
     /// Relative file path within the repository (e.g., "src/main.rs")
     pub path: String,
-    /// SHA1 hash of the blob in "sha1:HEXSTRING" format (case-insensitive, normalized to lowercase)
+    /// ObjectHash hash of the blob in "sha1:HEXSTRING" format (case-insensitive, normalized to lowercase)
     /// Already saved in raw_blob table
     /// Example: "sha1:da39a3ee5e6b4b0d3255bfef95601890afd80709"
     pub blob_id: String,
@@ -199,8 +199,10 @@ impl FileChange {
     /// Parse and validate blob hash format
     ///
     /// Expects format: "sha1:HEXSTRING" (case-insensitive, normalized to lowercase)
-    /// Returns the parsed SHA1 hash or an error if format is invalid
-    pub fn parse_blob_hash(&self) -> Result<git_internal::hash::SHA1, common::errors::MegaError> {
+    /// Returns the parsed ObjectHash hash or an error if format is invalid
+    pub fn parse_blob_hash(
+        &self,
+    ) -> Result<git_internal::hash::ObjectHash, common::errors::MegaError> {
         parse_sha1_hash(&self.blob_id, "blob_id")
     }
 

--- a/ceres/src/model/buck.rs
+++ b/ceres/src/model/buck.rs
@@ -48,7 +48,7 @@ pub struct ManifestFile {
     pub hash: String,
 }
 
-/// Parse and validate ObjectHash hash in "sha1:HEXSTRING" format
+/// Parse and validate ObjectHash in "sha1:HEXSTRING" format
 ///
 /// This is a shared helper function used by both ManifestFile and FileChange.
 /// It normalizes the hash to lowercase for consistency with Git conventions.
@@ -58,7 +58,7 @@ pub struct ManifestFile {
 /// * `field_name` - The name of the field (for error messages)
 ///
 /// # Returns
-/// The parsed ObjectHash hash or an error if format is invalid
+/// The parsed ObjectHash or an error if format is invalid
 pub fn parse_sha1_hash(
     input: &str,
     field_name: &str,
@@ -82,7 +82,7 @@ pub fn parse_sha1_hash(
     match algorithm.as_str() {
         "sha1" => ObjectHash::from_str(&hash_hex).map_err(|e| {
             MegaError::Other(format!(
-                "Invalid ObjectHash hash in {}: '{}', error: {}",
+                "Invalid ObjectHash in {}: '{}', error: {}",
                 field_name, hash_hex, e
             ))
         }),
@@ -97,7 +97,7 @@ impl ManifestFile {
     /// Parse and validate hash format
     ///
     /// Expects format: "sha1:HEXSTRING" (case-insensitive, normalized to lowercase)
-    /// Returns the parsed ObjectHash hash or an error if format is invalid
+    /// Returns the parsed ObjectHash or an error if format is invalid
     pub fn parse_hash(&self) -> Result<git_internal::hash::ObjectHash, common::errors::MegaError> {
         parse_sha1_hash(&self.hash, "hash field")
     }
@@ -179,7 +179,7 @@ pub struct CompleteResponse {
 pub struct FileChange {
     /// Relative file path within the repository (e.g., "src/main.rs")
     pub path: String,
-    /// ObjectHash hash of the blob in "sha1:HEXSTRING" format (case-insensitive, normalized to lowercase)
+    /// ObjectHash of the blob in "sha1:HEXSTRING" format (case-insensitive, normalized to lowercase)
     /// Already saved in raw_blob table
     /// Example: "sha1:da39a3ee5e6b4b0d3255bfef95601890afd80709"
     pub blob_id: String,
@@ -199,7 +199,7 @@ impl FileChange {
     /// Parse and validate blob hash format
     ///
     /// Expects format: "sha1:HEXSTRING" (case-insensitive, normalized to lowercase)
-    /// Returns the parsed ObjectHash hash or an error if format is invalid
+    /// Returns the parsed ObjectHash or an error if format is invalid
     pub fn parse_blob_hash(
         &self,
     ) -> Result<git_internal::hash::ObjectHash, common::errors::MegaError> {

--- a/ceres/src/model/change_list.rs
+++ b/ceres/src/model/change_list.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 use callisto::{check_result, sea_orm_active_enums::MergeStatusEnum};
 use common::model::CommonPage;
 use common::model::DiffItem;
-use git_internal::hash::SHA1;
+use git_internal::hash::ObjectHash;
 use jupiter::model::cl_dto::CLDetails;
 use jupiter::model::common::ListParams;
 
@@ -299,10 +299,10 @@ pub struct CloneRepoPayload {
 
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
 pub enum ClDiffFile {
-    New(PathBuf, SHA1),
-    Deleted(PathBuf, SHA1),
+    New(PathBuf, ObjectHash),
+    Deleted(PathBuf, ObjectHash),
     // path, old_hash, new_hash
-    Modified(PathBuf, SHA1, SHA1),
+    Modified(PathBuf, ObjectHash, ObjectHash),
 }
 
 impl ClDiffFile {
@@ -325,7 +325,7 @@ impl ClDiffFile {
 
 #[derive(Serialize)]
 pub struct BuckFile {
-    pub buck: SHA1,
-    pub buck_config: SHA1,
+    pub buck: ObjectHash,
+    pub buck_config: ObjectHash,
     pub path: PathBuf,
 }

--- a/ceres/src/pack/import_repo.rs
+++ b/ceres/src/pack/import_repo.rs
@@ -263,6 +263,12 @@ impl RepoHandler for ImportRepo {
                         pack_offset: Some(blob.pack_offset as usize),
                         file_path: Some(blob.file_path.clone()),
                         is_delta: Some(blob.is_delta_in_pack),
+                        // NOTE: We currently do not have CRC32 information available in the
+                        // blob metadata returned from `git_db_storage()`. Downstream callers
+                        // treat `None` as "CRC32 unknown" rather than "CRC32 invalid". Once
+                        // pack index entries (or another source) expose CRC32 for these blobs,
+                        // this should be populated with the actual checksum instead of `None`.
+                        // TODO: Thread CRC32 from the underlying Git storage into `EntryMeta`.
                         crc32: None,
                     },
                 )

--- a/ceres/src/pack/mod.rs
+++ b/ceres/src/pack/mod.rs
@@ -22,7 +22,7 @@ use common::{
     errors::{MegaError, ProtocolError},
     utils::ZERO_ID,
 };
-use git_internal::hash::SHA1;
+use git_internal::hash::ObjectHash;
 use git_internal::internal::metadata::{EntryMeta, MetaAttached};
 use git_internal::internal::pack::Pack;
 use git_internal::{
@@ -48,7 +48,7 @@ pub trait RepoHandler: Send + Sync + 'static {
     async fn receiver_handler(
         self: Arc<Self>,
         mut rx: UnboundedReceiver<MetaAttached<Entry, EntryMeta>>,
-        _rx_pack_id: UnboundedReceiver<SHA1>,
+        _rx_pack_id: UnboundedReceiver<ObjectHash>,
     ) -> Result<(), MegaError> {
         let mut entry_list = vec![];
         let semaphore = Arc::new(Semaphore::new(1)); //这里暂时改动
@@ -182,7 +182,7 @@ pub trait RepoHandler: Send + Sync + 'static {
     ) -> Result<
         (
             UnboundedReceiver<MetaAttached<Entry, EntryMeta>>,
-            UnboundedReceiver<SHA1>,
+            UnboundedReceiver<ObjectHash>,
         ),
         ProtocolError,
     > {

--- a/ceres/src/pack/monorepo.rs
+++ b/ceres/src/pack/monorepo.rs
@@ -362,7 +362,10 @@ impl RepoHandler for MonoRepo {
                         pack_offset: Some(blob.pack_offset as usize),
                         file_path: Some(blob.file_path.clone()),
                         is_delta: Some(blob.is_delta_in_pack),
-                        crc32: None, //tmp fix
+                        // TODO: Populate `crc32` once mono blob metadata exposes it.
+                        // For now we set it to `None` because `get_mega_blobs_by_hashes` does
+                        // not provide CRC32 information for monorepo-backed packs.
+                        crc32: None,
                     },
                 )
             })

--- a/jupiter/src/service/buck_service.rs
+++ b/jupiter/src/service/buck_service.rs
@@ -500,7 +500,7 @@ impl BuckService {
         // Validate ObjectHash format
         if hash_str.len() != 40 {
             return Err(BuckError::ValidationError(format!(
-                "Invalid ObjectHash hash length: expected 40, got {}",
+                "Invalid ObjectHash length: expected 40, got {}",
                 hash_str.len()
             ))
             .into());

--- a/jupiter/src/service/buck_service.rs
+++ b/jupiter/src/service/buck_service.rs
@@ -497,10 +497,10 @@ impl BuckService {
     pub fn parse_hash(&self, hash: &str) -> Result<String, MegaError> {
         let hash_str = hash.strip_prefix("sha1:").unwrap_or(hash);
 
-        // Validate SHA1 format
+        // Validate ObjectHash format
         if hash_str.len() != 40 {
             return Err(BuckError::ValidationError(format!(
-                "Invalid SHA1 hash length: expected 40, got {}",
+                "Invalid ObjectHash hash length: expected 40, got {}",
                 hash_str.len()
             ))
             .into());

--- a/jupiter/src/utils/converter.rs
+++ b/jupiter/src/utils/converter.rs
@@ -568,8 +568,8 @@ impl FromMegaModel for Tag {
     /// # Panics
     ///
     /// This function will panic if:
-    /// - The tag_id string cannot be parsed into a valid ObjectHash hash
-    /// - The object_id string cannot be parsed into a valid ObjectHash hash
+    /// - The tag_id string cannot be parsed into a valid ObjectHash
+    /// - The object_id string cannot be parsed into a valid ObjectHash
     /// - The object_type string is not a recognized ObjectType
     /// - The tagger string cannot be converted into a valid Signature
     fn from_mega_model(model: Self::MegaSource) -> Self {
@@ -604,8 +604,8 @@ impl FromGitModel for Tag {
     /// # Panics
     ///
     /// This function will panic if:
-    /// - The tag_id string cannot be parsed into a valid ObjectHash hash
-    /// - The object_id string cannot be parsed into a valid ObjectHash hash
+    /// - The tag_id string cannot be parsed into a valid ObjectHash
+    /// - The object_id string cannot be parsed into a valid ObjectHash
     /// - The object_type string is not a recognized ObjectType
     /// - The tagger string cannot be converted into a valid Signature
     fn from_git_model(model: Self::GitSource) -> Self {
@@ -627,7 +627,7 @@ impl FromMegaModel for Tree {
     ///
     /// This function reconstructs a Tree object from a mega_tree::Model retrieved from the database.
     /// It parses the binary sub_trees data back into a structured Tree object and
-    /// uses the tree_id string to recreate the ObjectHash hash identifier.
+    /// uses the tree_id string to recreate the ObjectHash identifier.
     ///
     /// # Arguments
     ///
@@ -640,7 +640,7 @@ impl FromMegaModel for Tree {
     /// # Panics
     ///
     /// This function will panic if:
-    /// - The tree_id string cannot be parsed into a valid ObjectHash hash
+    /// - The tree_id string cannot be parsed into a valid ObjectHash
     /// - The binary sub_trees data cannot be parsed into a valid Tree structure
     fn from_mega_model(model: Self::MegaSource) -> Self {
         Tree::from_bytes(
@@ -671,7 +671,7 @@ impl FromGitModel for Tree {
     /// # Panics
     ///
     /// This function will panic if:
-    /// - The tree_id string cannot be parsed into a valid ObjectHash hash
+    /// - The tree_id string cannot be parsed into a valid ObjectHash
     /// - The binary sub_trees data cannot be parsed into a valid Tree structure
     fn from_git_model(model: Self::GitSource) -> Self {
         Tree::from_bytes(
@@ -702,9 +702,9 @@ impl FromMegaModel for Commit {
     /// # Panics
     ///
     /// This function will panic if:
-    /// - The commit_id string cannot be parsed into a valid ObjectHash hash
-    /// - The tree string cannot be parsed into a valid ObjectHash hash
-    /// - Any parent ID in parents_id cannot be parsed into a valid ObjectHash hash
+    /// - The commit_id string cannot be parsed into a valid ObjectHash
+    /// - The tree string cannot be parsed into a valid ObjectHash
+    /// - Any parent ID in parents_id cannot be parsed into a valid ObjectHash
     /// - The author or committer strings cannot be converted into valid Signatures
     fn from_mega_model(model: Self::MegaSource) -> Self {
         commit_from_model(
@@ -760,7 +760,7 @@ impl FromMegaModel for Blob {
     /// Converts a raw_blob::Model to a Blob object
     ///
     /// This function extracts the necessary data from a raw_blob::Model
-    /// to create a new Blob object. It parses the ObjectHash hash from the string
+    /// to create a new Blob object. It parses the ObjectHash from the string
     /// representation and unwraps the binary data.
     ///
     /// # Arguments
@@ -773,8 +773,7 @@ impl FromMegaModel for Blob {
     ///
     /// # Panics
     ///
-    /// This function will panic if the ObjectHash string cannot be parsed or if
-    /// the data field is None
+    /// This function will panic if the hash string cannot be parsed into a valid ObjectHash
     fn from_mega_model(model: Self::MegaSource) -> Self {
         Blob {
             id: ObjectHash::from_str(&model.sha1).unwrap(),

--- a/mono/tests/buck_service_tests.rs
+++ b/mono/tests/buck_service_tests.rs
@@ -1054,7 +1054,7 @@ async fn test_upload_file_hash_verification_success() {
 // Section 5: BuckService::complete_upload Tests
 // ============================================================================
 
-use git_internal::hash::SHA1;
+use git_internal::hash::ObjectHash;
 use git_internal::internal::metadata::EntryMeta;
 use git_internal::internal::object::commit::Commit;
 use git_internal::internal::object::tree::{Tree, TreeItem, TreeItemMode};
@@ -1072,7 +1072,7 @@ fn create_test_commit_artifacts(
     // Create a simple tree with one blob
     let tree = Tree::from_tree_items(vec![TreeItem {
         mode: TreeItemMode::Blob,
-        id: SHA1::from_str(tree_hash).unwrap(),
+        id: ObjectHash::from_str(tree_hash).unwrap(),
         name: "test.txt".to_string(),
     }])
     .unwrap();
@@ -1080,7 +1080,11 @@ fn create_test_commit_artifacts(
     let tree_model = tree.into_mega_model(EntryMeta::default());
 
     // Create a commit
-    let commit = Commit::from_tree_id(SHA1::from_str(tree_hash).unwrap(), vec![], "Test commit");
+    let commit = Commit::from_tree_id(
+        ObjectHash::from_str(tree_hash).unwrap(),
+        vec![],
+        "Test commit",
+    );
 
     let commit_model = commit.into_mega_model(EntryMeta::default());
 

--- a/scorpio/Cargo.toml
+++ b/scorpio/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 ceres = { path = "../ceres" }
-
+git-internal = { workspace = true }
 reqwest =  { version = "0.12.7", features = ["json","blocking"] }
 serde = { version = "1.0.210", features = ["derive"] }
 tokio = { version = "1.40.0", features = ["full"] }
@@ -59,7 +59,7 @@ dashmap = "6.1.0"
 chrono = "0.4.24"
 ring = "0.17.8"
 hex = "0.4.3"
-git-internal = "0.1.0"
+
 async-trait.workspace = true
 tracing-subscriber.workspace = true
 

--- a/scorpio/src/daemon/mod.rs
+++ b/scorpio/src/daemon/mod.rs
@@ -9,7 +9,7 @@ use axum::extract::{Path, State};
 use axum::routing::{get, post};
 use axum::Router;
 use dashmap::DashMap;
-use git_internal::hash::SHA1;
+use git_internal::hash::ObjectHash;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use uuid::Uuid;
@@ -249,7 +249,7 @@ async fn perform_mount_task(state: ScoState, req: MountRequest) -> Result<MountI
     // Handle temporary mount case (typically for buck2)
     if temp_mount {
         let temp_hash = {
-            let hasher = SHA1::new(mono_path.as_bytes());
+            let hasher = ObjectHash::new(mono_path.as_bytes());
             hasher.to_string()
         };
 

--- a/scorpio/src/dicfuse/store.rs
+++ b/scorpio/src/dicfuse/store.rs
@@ -28,7 +28,7 @@ use super::size_store::SizeStorage;
 use super::tree_store::{StorageItem, TreeStorage};
 use crate::util::{config, GPath};
 
-/// Git ObjectHash for an empty blob (0-byte file).
+/// Git hash (ObjectHash type) for an empty blob (0-byte file).
 ///
 /// This lets us distinguish legitimate empty files from failures (e.g., network/HTTP errors)
 /// that must NOT be cached as empty content.

--- a/scorpio/src/dicfuse/store.rs
+++ b/scorpio/src/dicfuse/store.rs
@@ -28,7 +28,7 @@ use super::size_store::SizeStorage;
 use super::tree_store::{StorageItem, TreeStorage};
 use crate::util::{config, GPath};
 
-/// Git SHA1 for an empty blob (0-byte file).
+/// Git ObjectHash for an empty blob (0-byte file).
 ///
 /// This lets us distinguish legitimate empty files from failures (e.g., network/HTTP errors)
 /// that must NOT be cached as empty content.

--- a/scorpio/src/manager/cl.rs
+++ b/scorpio/src/manager/cl.rs
@@ -143,7 +143,7 @@ pub async fn build_cl_layer(
                 if let Some(parent) = file_path.parent() {
                     std::fs::create_dir_all(parent).map_err(ClLayerError::DirectoryError)?;
                 }
-                // Parse SHA1 from string and add to download queue
+                // Parse ObjectHash from string and add to download queue
                 let file_id = file
                     .sha
                     .parse()

--- a/scorpio/src/manager/cl.rs
+++ b/scorpio/src/manager/cl.rs
@@ -143,7 +143,7 @@ pub async fn build_cl_layer(
                 if let Some(parent) = file_path.parent() {
                     std::fs::create_dir_all(parent).map_err(ClLayerError::DirectoryError)?;
                 }
-                // Parse ObjectHash from string and add to download queue
+                // Parse hash (ObjectHash type) from string and add to download queue
                 let file_id = file
                     .sha
                     .parse()

--- a/scorpio/src/manager/diff.rs
+++ b/scorpio/src/manager/diff.rs
@@ -1,4 +1,4 @@
-use git_internal::hash::SHA1;
+use git_internal::hash::ObjectHash;
 use git_internal::internal::object::blob::Blob;
 use git_internal::internal::object::tree::{Tree, TreeItem, TreeItemMode};
 use git_internal::internal::object::types::ObjectType;
@@ -93,7 +93,7 @@ pub fn diff(
                     // node is a changed ()blob.
                     // just compute the NEW hash first.
                     let content = std::fs::read(&node)?;
-                    item.id = SHA1::from_type_and_data(ObjectType::Blob, &content);
+                    item.id = ObjectHash::from_type_and_data(ObjectType::Blob, &content);
                     blobs.push(Blob::from_content_bytes(content));
                 }
                 break;
@@ -113,7 +113,7 @@ pub fn diff(
                 // is dictionary.
                 t.tree_items.push(TreeItem {
                     mode: TreeItemMode::Tree,
-                    id: SHA1::default(),
+                    id: ObjectHash::default(),
                     name: new_name,
                 });
             } else {

--- a/scorpio/src/manager/fetch.rs
+++ b/scorpio/src/manager/fetch.rs
@@ -7,7 +7,7 @@ use async_recursion::async_recursion;
 use ceres::model::git::LatestCommitInfo;
 use crossbeam::queue::SegQueue;
 use futures::future::join_all;
-use git_internal::hash::SHA1;
+use git_internal::hash::ObjectHash;
 use git_internal::internal::object::tree::{Tree, TreeItemMode};
 use git_internal::internal::object::{
     commit::Commit,
@@ -32,13 +32,13 @@ use tokio::time::Duration;
 ///Download a file needs it's blob_id and save_path.
 #[derive(Debug, Clone)]
 pub struct DownloadTask {
-    file_id: SHA1,
+    file_id: ObjectHash,
     save_path: PathBuf,
     retry_count: u32,
 }
 
 impl DownloadTask {
-    pub fn new(file_id: SHA1, save_path: PathBuf) -> Self {
+    pub fn new(file_id: ObjectHash, save_path: PathBuf) -> Self {
         Self {
             file_id,
             save_path,
@@ -71,7 +71,7 @@ impl DownloadTask {
 ///
 /// 2. **File Download Phase**:
 ///    - File download tasks are processed by a fixed pool of worker threads
-///    - Each task downloads a file from the server using its SHA1 hash
+///    - Each task downloads a file from the server using its ObjectHash hash
 ///    - Workers update the `pending_tasks` counter as they complete downloads
 ///
 /// 3. **Completion Coordination**:
@@ -318,7 +318,7 @@ impl DownloadManager {
 }
 
 /// Enqueue a file download task,the common entry point for downloading files.
-pub fn enqueue_file_download(file_id: SHA1, save_path: PathBuf) {
+pub fn enqueue_file_download(file_id: ObjectHash, save_path: PathBuf) {
     let download_manager = DownloadManager::get_global();
     let task = DownloadTask::new(file_id, save_path);
 
@@ -329,7 +329,7 @@ pub fn enqueue_file_download(file_id: SHA1, save_path: PathBuf) {
 
 /// Download multiple files for CL scenarios.
 pub async fn download_cl_files(
-    files: Vec<(SHA1, PathBuf)>,
+    files: Vec<(ObjectHash, PathBuf)>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let download_manager = DownloadManager::get_global();
 
@@ -791,7 +791,7 @@ async fn _set_parent_commit(work_path: &Path, repo_path: &str) -> std::io::Resul
 
 /// Network operations, extracting Blobs objects from HTTP byte streams and storing them
 async fn fetch_and_save_file(
-    url: &SHA1,
+    url: &ObjectHash,
     save_path: impl AsRef<Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::new();
@@ -865,7 +865,7 @@ pub async fn fetch_parent_commit(path: &str) -> Result<Commit, Box<dyn std::erro
         Ok(Commit::new(
             author_sign,
             committer_sign,
-            SHA1::from_str(&parent_info.oid)?,
+            ObjectHash::from_str(&parent_info.oid)?,
             Vec::new(),
             &parent_info.short_message,
         ))

--- a/scorpio/src/manager/fetch.rs
+++ b/scorpio/src/manager/fetch.rs
@@ -71,7 +71,7 @@ impl DownloadTask {
 ///
 /// 2. **File Download Phase**:
 ///    - File download tasks are processed by a fixed pool of worker threads
-///    - Each task downloads a file from the server using its ObjectHash hash
+///    - Each task downloads a file from the server using its ObjectHash
 ///    - Workers update the `pending_tasks` counter as they complete downloads
 ///
 /// 3. **Completion Coordination**:

--- a/scorpio/src/manager/mod.rs
+++ b/scorpio/src/manager/mod.rs
@@ -4,7 +4,7 @@ use add::add_and_del;
 use commit::commit_core;
 use fs_extra::dir::{copy, CopyOptions};
 use git_internal::{
-    hash::SHA1,
+    hash::ObjectHash,
     internal::object::{
         commit::Commit,
         signature::{Signature, SignatureType},
@@ -101,7 +101,7 @@ impl ScorpioManager {
         let parent_commit = fs::read_to_string(&commitpath)?;
         let regex_rule = Regex::new(r#"tree: (?<parent_hash>[0-9a-z]{40})"#).unwrap();
         let parent_hash = match regex_rule.captures(&parent_commit) {
-            Some(parent_info) => vec![SHA1::from_str(&parent_info["parent_hash"])?],
+            Some(parent_info) => vec![ObjectHash::from_str(&parent_info["parent_hash"])?],
             None => return Err(Box::from("Parent hash not found in commit file")),
         };
 

--- a/scorpio/src/manager/push.rs
+++ b/scorpio/src/manager/push.rs
@@ -71,7 +71,7 @@ pub async fn pack(commit: Commit, trees: Vec<Tree>, blob: Vec<Blob>) -> Vec<u8> 
     pack_data
 }
 
-/// Convert a String to a ObjectHash hash
+/// Convert a String to an ObjectHash
 fn string_to_sha(hash: &str) -> std::io::Result<ObjectHash> {
     ObjectHash::from_str(hash).map_err(|e| Error::new(ErrorKind::InvalidData, e))
 }

--- a/scorpio/src/manager/store.rs
+++ b/scorpio/src/manager/store.rs
@@ -1,4 +1,4 @@
-use git_internal::hash::SHA1;
+use git_internal::hash::ObjectHash;
 use git_internal::internal::object::ObjectTrait;
 use git_internal::internal::object::{blob::Blob, commit::Commit, tree::Tree};
 use std::collections::HashMap;
@@ -199,8 +199,8 @@ impl BlobFsStore for PathBuf {
                     "Hash must be 40 characters long",
                 ))?;
                 let hash_path = object_path.join(hash_flag);
-                let sha_hash =
-                    SHA1::from_str(hash).map_err(|e| Error::new(ErrorKind::InvalidInput, e))?;
+                let sha_hash = ObjectHash::from_str(hash)
+                    .map_err(|e| Error::new(ErrorKind::InvalidInput, e))?;
 
                 let data_path = hash_path.join(&hash[2..]);
                 let data = std::fs::read(&data_path)?;
@@ -589,7 +589,7 @@ impl TempStoreArea {
 #[cfg(test)]
 mod test {
     use git_internal::{
-        hash::SHA1,
+        hash::ObjectHash,
         internal::object::tree::{Tree, TreeItem, TreeItemMode},
     };
     use std::vec;
@@ -603,7 +603,7 @@ mod test {
         let db = sled::open(db_path).unwrap();
         let t = Tree::from_tree_items(vec![TreeItem::new(
             TreeItemMode::Blob,
-            SHA1::new(&[4u8, 4u8, 4u8, 64u8, 84u8, 84u8]),
+            ObjectHash::new(&[4u8, 4u8, 4u8, 64u8, 84u8, 84u8]),
             String::from("test"),
         )])
         .unwrap();

--- a/scorpio/src/scolfs/ext.rs
+++ b/scorpio/src/scolfs/ext.rs
@@ -4,18 +4,18 @@ use std::{
 };
 
 use crate::utils::lfs::generate_pointer_file;
-use git_internal::{hash::SHA1, internal::object::blob::Blob};
+use git_internal::{hash::ObjectHash, internal::object::blob::Blob};
 
 use crate::scolfs::lfs::backup_lfs_file;
 #[allow(unused)]
 pub trait BlobExt {
-    fn load(hash: &SHA1) -> Blob;
+    fn load(hash: &ObjectHash) -> Blob;
     fn from_file(path: impl AsRef<Path>) -> Blob;
     fn from_lfs_file(path: impl AsRef<Path>) -> Blob;
-    fn save(&self) -> SHA1;
+    fn save(&self) -> ObjectHash;
 }
 impl BlobExt for Blob {
-    fn load(_hash: &SHA1) -> Blob {
+    fn load(_hash: &ObjectHash) -> Blob {
         todo!()
     }
 
@@ -39,7 +39,7 @@ impl BlobExt for Blob {
         Blob::from_content(&pointer)
     }
 
-    fn save(&self) -> SHA1 {
+    fn save(&self) -> ObjectHash {
         todo!();
     }
 }


### PR DESCRIPTION
#1751 

## Summary

This PR upgrades and unifies the usage of `git-internal` across the entire workspace.

Previously, different crates referenced `git-internal` inconsistently, which caused
dependency resolution issues when using `workspace.dependencies`.
This change centralizes the dependency definition at the workspace root and ensures
all member crates inherit it consistently.

## What has been changed

- Upgraded `git-internal` to a unified version at the workspace level
- Standardized dependency naming and inheritance via `workspace.dependencies`

## Important Notes

- ⚠️ This PR **only upgrades and unifies the existing `git-internal` dependency**
- ⚠️ The project **still relies on SHA-1** internally at this stage
- ⚠️ **SHA-256 is NOT introduced in this PR**

The goal of this change is to establish a clean and stable dependency baseline.
Support for SHA-256 will be introduced incrementally in follow-up PRs to avoid
large, risky changes in a single step.