### PR TITLE
feat: Add Docker Compose configuration for Mega Dev Image

### DIFF
--- a/.github/workflows/mega-dev-image-deploy.yml
+++ b/.github/workflows/mega-dev-image-deploy.yml
@@ -25,6 +25,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -51,9 +57,9 @@ jobs:
           IMAGE_BASE="$REGISTRY/$REGISTRY_ALIAS/$REPOSITORY"
 
           docker buildx build \
+            --platform linux/amd64,linux/arm64 \
             --target runtime \
             -t "$IMAGE_BASE:$IMAGE_TAG" \
             -t "$IMAGE_BASE:$IMAGE_TAG-$TIMESTAMP" \
             -f docker/dev-image/Dockerfile \
             --push .
-

--- a/.github/workflows/mega-dev-image-deploy.yml
+++ b/.github/workflows/mega-dev-image-deploy.yml
@@ -1,0 +1,59 @@
+name: Mega Dev Image deploy
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/mega-dev-image-deploy.yml"
+      - "docker/dev-image/**"
+      - "orion/**"
+      - "scorpio/**"
+      - "ceres/**"
+      - "jupiter/**"
+      - "common/**"
+      - "context/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Build, tag, and push dev image to Amazon ECR Public
+        env:
+          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+          REGISTRY_ALIAS: m8q5m4u3
+          REPOSITORY: mega
+          IMAGE_TAG: mega-dev-0.1.0-pre-release
+        run: |
+          set -euo pipefail
+          TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+
+          IMAGE_BASE="$REGISTRY/$REGISTRY_ALIAS/$REPOSITORY"
+
+          docker buildx build \
+            --target runtime \
+            -t "$IMAGE_BASE:$IMAGE_TAG" \
+            -t "$IMAGE_BASE:$IMAGE_TAG-$TIMESTAMP" \
+            -f docker/dev-image/Dockerfile \
+            --push .
+

--- a/config/config-test.toml
+++ b/config/config-test.toml
@@ -1,0 +1,224 @@
+# the directory where the data files is located, such as logs, database, etc.
+# can be overridden by environment variable `MEGA_BASE_DIR`
+# When using monobean, this option will be ignored, you should set it in monobean preference GUI.
+base_dir = "/tmp/.mono"
+
+# Filling the following environment variables with values you set
+## Logging Configuration
+[log]
+# The path which log file is saved
+log_path = "${base_dir}/logs"
+
+# log level, can be "trace", "debug", "info", "warn", "error"
+level = "debug"
+
+# print std log in console, disable it on production for performance
+print_std = true
+
+
+[database]
+# "sqlite" | "postgres"
+# "sqlite" will use `db_path` and ignore `db_url`
+db_type = "postgres"
+
+# used for sqlite
+db_path = "${base_dir}/mega.db"
+
+# database connection url, set to "postgres://mono:mono@mono-pg:5432/mono" if you're using docker
+db_url = "postgres://mono:mono@localhost:5432/mono"
+#db_url = "postgres://mono:mono@127.0.0.1:5432/mono"
+
+# Maximum number of database connections in the pool.
+# A good rule of thumb is to set this to ~2 × CPU cores.
+max_connection = 16
+
+# Minimum number of database connections maintained in the pool.
+# Typically set to ~1 × CPU cores to ensure baseline concurrency.
+min_connection = 8
+
+# Timeout (in seconds) for acquiring a connection from the pool.
+# If exceeded, the request will fail.
+acquire_timeout = 3
+
+# Timeout (in seconds) for establishing a new database connection.
+# If exceeded, the connection attempt will fail.
+connect_timeout = 3
+
+# Whether to enable SQLx logging
+sqlx_logging = false
+
+[authentication]
+# Support http authentication, login in with github and generate token before push
+enable_http_auth = false
+
+# Enable a test user for debugging and development purposes.
+# If set to true, the service allows using a predefined test user for authentication.
+enable_test_user = true
+
+# Specify the name of the test user.
+# This is only relevant if `enable_test_user` is set to true.
+test_user_name = "mega"
+
+# Specify the token for the test user.
+# This is used for authentication when `enable_test_user` is set to true.
+test_user_token = "mega"
+
+[monorepo]
+## Only import directory support multi-branch commit and tag, monorepo only support main branch
+## Mega treats files under this directory as import repo and other directories as monorepo
+import_dir = "/third-party"
+
+# Set System Admin in directory init, replace the admin's github username here
+admin = "admin"
+
+# Set serveral root dirs in directory init
+root_dirs = ["third-party", "project", "doc", "release", "model"]
+
+# git object storage type, support values can be "local_fs" or "s3"
+storage_type = "local_fs"
+
+[build]
+
+# enable build system trigger
+enable_build = false
+
+# build system url
+orion_server = "https://orion.gitmega.com"
+
+
+[pack]
+# The maximum memory used by decode
+# Support the following units/notations: K, M, G, T, KB, MB, GB, TB, KiB, MiB, GiB, TiB, `%` and decimal percentages
+# Capacity units are case-insensitive and can also be spelled as mb or Mb
+# Abbreviated units are treated as binary byte units, for example M is treated as MiB
+pack_decode_mem_size = "4G"
+pack_decode_disk_size = "20%"
+
+# The location where the object stored when the memory used by decode exceeds the limit
+pack_decode_cache_path = "${base_dir}/cache"
+
+clean_cache_after_decode = true
+
+# The maximum message size in channel buffer while decode
+channel_message_size = 1_000_000
+
+[lfs]
+# lfs file storage type, support values can be "local_fs" or "s3"
+storage_type = "local_fs"
+
+[lfs.ssh]
+# The lfs ssh transport protocol still relies on http to send files
+http_url = "http://localhost:8000"
+
+[lfs.local]
+# set the local path of the lfs storage
+lfs_file_path = "${base_dir}/lfs"
+
+## IMPORTANT: The 'enable_split' feature can only be enabled for new databases. Existing databases do not support this feature.
+# Enable or disable splitting large files into smaller chunks
+enable_split = true # Default is disabled. Set to true to enable file splitting.
+
+# Size of each file chunk when splitting is enabled. Ignored if splitting is disabled.
+split_size = "20M"
+
+
+[s3]
+# AWS region name.
+# For AWS S3 this must match the bucket's region.
+# For S3-compatible services (e.g. RustFS), this is usually ignored
+# but still required by the AWS SDK.
+region = "us-east-1"
+
+# Name of the S3 bucket used to store objects.
+# The bucket must already exist, or the application should create it on startup.
+bucket = "mega"
+
+# Access key ID for S3 authentication.
+# For AWS: IAM user's access key.
+# For S3-compatible services: service-specific access key.
+access_key_id = ""
+
+# Secret access key corresponding to the access_key_id.
+# Keep this value secure and never commit it to version control.
+secret_access_key = ""
+
+
+# Custom S3 endpoint URL.
+# Use the default AWS endpoint when empty.
+# For local or self-hosted S3-compatible services (e.g. RustFS),
+# set this to the service endpoint.
+endpoint_url = "http://localhost:9000"
+
+
+[oauth]
+# GitHub OAuth application client id and secret
+github_client_id = ""
+github_client_secret = ""
+
+# Used for redirect to ui after login, for example: http://app.gitmega.com
+ui_domain = "http://local.gitmega.com"
+
+# Set your own domain here, for example: .gitmono.com
+cookie_domain = "localhost"
+
+# Used for call api from campsite server, for example: http://api.gitmono.test:3001
+campsite_api_domain = "http://api.gitmono.test:3001"
+
+# allowed cors origins
+allowed_cors_origins = [
+    "http://local.gitmega.com",
+    "https://app.gitmega.com",
+    "http://app.gitmono.test",
+]
+
+[blame]
+# Configuration for blame functionality and large file handling
+# Maximum number of lines before considering a file as large
+max_lines_threshold = 1000
+
+# Maximum file size in bytes before considering a file as large
+# Support the following units/notations: K, M, G, T, KB, MB, GB, TB, KiB, MiB, GiB, TiB
+max_size_threshold = "1MB"
+
+# Default chunk size for streaming operations when processing large files
+default_chunk_size = 100
+
+# Maximum number of commits to process in memory at once during blame traversal
+max_commits_in_memory = 50
+
+# Enable caching of intermediate blame results for better performance
+enable_caching = true
+
+[redis]
+url = "redis://127.0.0.1:6379"
+
+# Buck upload API configuration (optional)
+# Uncomment the following section to customize upload settings
+[buck]
+# Session timeout in seconds (default: 3600 = 1 hour)
+session_timeout = 3600
+# Maximum file size (default: "100MB")
+max_file_size = "100MB"
+# Maximum number of files per session (default: 1000)
+max_files = 1000
+# Maximum concurrent uploads (default: 5) - returned to client as suggestion
+max_concurrent_uploads = 5
+
+# === Server-side rate limiting ===
+# Global upload concurrency limit (default: 50)
+# Controls total concurrent upload requests being processed
+upload_concurrency_limit = 50
+# Large file concurrency limit (default: 10)
+# Controls concurrent large file uploads to prevent memory exhaustion
+large_file_concurrency_limit = 10
+# Large file threshold (default: "1MB")
+# Files larger than this are subject to additional concurrency limits
+large_file_threshold = "1MB"
+
+# Enable session cleanup task (default: true)
+enable_session_cleanup = true
+# Cleanup task interval in seconds (default: 300 = 5 minutes)
+cleanup_interval = 300
+# Retention days for completed sessions (default: 7)
+# Completed sessions older than this will be deleted along with file records
+completed_retention_days = 7

--- a/docker/dev-image/.env.example
+++ b/docker/dev-image/.env.example
@@ -1,0 +1,68 @@
+# =============================================================================
+# Mega Dev Image - Environment Configuration (Client Toolchain)
+# =============================================================================
+# Copy this file to .env and modify as needed.
+#
+# This image provides:
+# - Scorpio daemon (FUSE + HTTP API)
+# - Orion Worker (optional; connects to external Orion Server)
+# - Buck2 CLI
+#
+# NOTE: Scorpio needs a running Mono (Mega main service) to fetch repository content.
+# Configure `SCORPIO_BASE_URL` / `SCORPIO_LFS_URL` to point to Mono.
+
+# ---------------------------------------------------------------------------
+# Common
+# ---------------------------------------------------------------------------
+RUST_LOG=info
+
+# ---------------------------------------------------------------------------
+# Scorpio (daemon) Configuration
+# ---------------------------------------------------------------------------
+# Mono/Mega service URL (required for real mounts)
+SCORPIO_BASE_URL=http://host.docker.internal:8000
+SCORPIO_LFS_URL=http://host.docker.internal:8000
+
+# Scorpio HTTP port
+SCORPIO_PORT=2725
+
+# Store path for Scorpio data (inside container)
+SCORPIO_STORE_PATH=/data/scorpio/store
+
+# Workspace root (inside container)
+SCORPIO_WORKSPACE=/workspace/mount
+
+# Git author info used by Scorpio operations
+SCORPIO_GIT_AUTHOR=MEGA
+SCORPIO_GIT_EMAIL=admin@mega.org
+
+# DicFuse configuration
+SCORPIO_DICFUSE_READABLE=true
+SCORPIO_LOAD_DIR_DEPTH=3
+SCORPIO_FETCH_FILE_THREAD=10
+
+# ---------------------------------------------------------------------------
+# Orion Worker (optional) Configuration
+# ---------------------------------------------------------------------------
+# Orion Server WebSocket URL (external service)
+SERVER_WS=ws://host.docker.internal:8004/ws
+
+# Optional fixed worker id (otherwise generated per session)
+# ORION_WORKER_ID=
+
+# Worker local paths (inside container)
+BUCK_PROJECT_ROOT=/workspace
+BUILD_TMP=/tmp/orion-builds
+
+# Scorpio API base URL used by the worker
+# - When ORION_WORKER_START_SCORPIO=true, this is usually the embedded Scorpio.
+SCORPIO_API_BASE_URL=http://127.0.0.1:2725
+
+# Start embedded Scorpio inside the worker container (recommended when the worker needs mounts)
+ORION_WORKER_START_SCORPIO=true
+
+# ---------------------------------------------------------------------------
+# Buck2 Configuration
+# ---------------------------------------------------------------------------
+BUCK2_ISOLATION_DIR=/tmp/buck2-isolation
+

--- a/docker/dev-image/Dockerfile
+++ b/docker/dev-image/Dockerfile
@@ -1,0 +1,277 @@
+# =============================================================================
+# Mega Dev Image - Multi-stage Dockerfile
+# =============================================================================
+# This Dockerfile builds a unified development image containing:
+# - Orion Worker (build execution client)
+# - Scorpio (FUSE filesystem service)
+# - Buck2 (build tool)
+#
+# Supports: linux/amd64, linux/arm64
+# Build targets: runtime (slim), dev (with Rust toolchain)
+# Optional build targets: runtime-nocache, dev-nocache (disable BuildKit cargo cache mounts)
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Build Arguments
+# -----------------------------------------------------------------------------
+# Use "bookworm" for latest stable, or specify version like "1.83"
+ARG RUST_VERSION=1.92-bookworm
+ARG RUST_TOOLCHAIN=1.92.0
+ARG BUCK2_VERSION=2025-06-01
+
+# =============================================================================
+# Stage 1: Builder Base - Prepare workspace
+# =============================================================================
+FROM rust:${RUST_VERSION} AS builder-base
+
+# Build arguments for version tracking
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+# Platform args (provided by buildx/BuildKit). Used to scope cache keys.
+ARG TARGETARCH
+ARG TARGETOS
+ARG TARGETPLATFORM
+
+WORKDIR /build
+
+RUN mkdir -p /build/bin
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    pkg-config \
+    cmake \
+    clang \
+    llvm-dev \
+    libclang-dev \
+    libssl-dev \
+    libfuse3-dev \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy entire project
+COPY . .
+
+# =============================================================================
+# Stage 1a: Builder (BuildKit cache enabled) - Compile Rust binaries
+# =============================================================================
+FROM builder-base AS builder
+
+RUN --mount=type=cache,id=mega-cargo-registry-${TARGETARCH},target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,id=mega-cargo-git-${TARGETARCH},target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,id=mega-cargo-target-${TARGETARCH},target=/build/target,sharing=locked \
+    CARGO_TARGET_DIR=/build/target cargo build --release --package orion --package scorpio \
+    && install -m 0755 /build/target/release/orion /build/bin/orion \
+    && install -m 0755 /build/target/release/scorpio /build/bin/scorpio
+
+# =============================================================================
+# Stage 1b: Builder (no BuildKit cache) - Compile Rust binaries
+# =============================================================================
+FROM builder-base AS builder-nocache
+
+RUN CARGO_TARGET_DIR=/build/target cargo build --release --package orion --package scorpio \
+    && install -m 0755 /build/target/release/orion /build/bin/orion \
+    && install -m 0755 /build/target/release/scorpio /build/bin/scorpio
+
+# =============================================================================
+# Stage 2: Buck2 Downloader - Fetch Buck2 binary
+# =============================================================================
+FROM debian:bookworm-slim AS buck2-downloader
+
+ARG BUCK2_VERSION
+ARG TARGETARCH
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    zstd \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /buck2
+
+# Download Buck2 based on architecture
+# Using official GitHub releases from facebook/buck2
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+        amd64) BUCK2_ARCH="x86_64-unknown-linux-musl" ;; \
+        arm64) BUCK2_ARCH="aarch64-unknown-linux-musl" ;; \
+        *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac; \
+    BUCK2_URL="https://github.com/facebook/buck2/releases/download/${BUCK2_VERSION}/buck2-${BUCK2_ARCH}.zst"; \
+    echo "Downloading Buck2 from: ${BUCK2_URL}"; \
+    curl -fsSL -o buck2.zst "${BUCK2_URL}"; \
+    zstd -d buck2.zst -o buck2; \
+    chmod +x buck2; \
+    ./buck2 --version
+
+# =============================================================================
+# Stage 3: Runtime Base - Minimal production image
+# =============================================================================
+FROM debian:bookworm-slim AS runtime-base
+
+# Build arguments for labels
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+ARG BUCK2_VERSION
+
+# Image metadata
+LABEL org.opencontainers.image.title="Mega Dev Image" \
+      org.opencontainers.image.description="Unified development image with Orion Worker, Scorpio, and Buck2" \
+      org.opencontainers.image.version="1.0.0" \
+      org.opencontainers.image.revision="${GIT_COMMIT}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.source="https://github.com/web3infra-foundation/mega" \
+      mega.orion.version="${GIT_COMMIT}" \
+      mega.orion_worker.version="${GIT_COMMIT}" \
+      mega.scorpio.version="${GIT_COMMIT}" \
+      mega.buck2.version="${BUCK2_VERSION}"
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    fuse3 \
+    libfuse3-3 \
+    libssl3 \
+    git \
+    git-lfs \
+    curl \
+    gettext-base \
+    netcat-openbsd \
+    procps \
+    && rm -rf /var/lib/apt/lists/* \
+    # Configure FUSE to allow other users
+    && echo "user_allow_other" >> /etc/fuse.conf
+
+# Create necessary directories
+RUN mkdir -p \
+    /app/bin \
+    /app/config \
+    /data/scorpio/store \
+    /data/scorpio/antares/upper \
+    /data/scorpio/antares/cl \
+    /data/scorpio/antares/mnt \
+    /workspace/mount
+
+# Copy Buck2 binary
+COPY --from=buck2-downloader /buck2/buck2 /usr/local/bin/
+
+# Copy configuration templates and scripts
+COPY docker/dev-image/scorpio.toml.template /app/config/
+COPY docker/dev-image/entrypoint.sh /app/
+
+# Write a small metadata file that the entrypoint can print for debugging.
+RUN printf "GIT_COMMIT=%s\nBUILD_DATE=%s\nBUCK2_VERSION=%s\n" "${GIT_COMMIT}" "${BUILD_DATE}" "${BUCK2_VERSION}" > /etc/mega-image-info
+
+# Make entrypoint executable
+RUN chmod +x /app/entrypoint.sh
+
+# Set environment variables
+ENV PATH="/app/bin:/usr/local/bin:${PATH}" \
+    RUST_LOG=info \
+    # Scorpio defaults
+    SCORPIO_STORE_PATH=/data/scorpio/store \
+    SCORPIO_WORKSPACE=/workspace/mount \
+    # Buck2 defaults
+    BUCK2_ISOLATION_DIR=/tmp/buck2-isolation
+
+WORKDIR /workspace
+
+ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["help"]
+
+# =============================================================================
+# Stage 3a: Runtime - Copy binaries built with cache
+# =============================================================================
+FROM runtime-base AS runtime
+
+COPY --from=builder /build/bin/orion /app/bin/
+COPY --from=builder /build/bin/scorpio /app/bin/
+
+# =============================================================================
+# Stage 3b: Runtime (no BuildKit cache) - Copy binaries built without cache
+# =============================================================================
+FROM runtime-base AS runtime-nocache
+
+COPY --from=builder-nocache /build/bin/orion /app/bin/
+COPY --from=builder-nocache /build/bin/scorpio /app/bin/
+
+# =============================================================================
+# Stage 4: Dev - Full development image with Rust toolchain
+# =============================================================================
+FROM runtime AS dev
+
+# Keep dev toolchain pinned (must be re-declared after FROM).
+ARG RUST_TOOLCHAIN
+
+# Install development tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    pkg-config \
+    cmake \
+    clang \
+    llvm-dev \
+    libclang-dev \
+    libssl-dev \
+    libfuse3-dev \
+    vim \
+    less \
+    jq \
+    htop \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust toolchain
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN} \
+    && . $HOME/.cargo/env \
+    && rustup component add rustfmt clippy rust-analyzer
+
+# Set Rust environment
+ENV PATH="/root/.cargo/bin:${PATH}" \
+    CARGO_HOME="/root/.cargo" \
+    RUSTUP_HOME="/root/.rustup"
+
+# Install additional Cargo tools
+RUN cargo install cargo-watch cargo-expand
+
+LABEL mega.image.type="dev"
+
+# =============================================================================
+# Stage 4b: Dev (no BuildKit cache) - Full development image with Rust toolchain
+# =============================================================================
+FROM runtime-nocache AS dev-nocache
+
+# Keep dev toolchain pinned (must be re-declared after FROM).
+ARG RUST_TOOLCHAIN
+
+# Install development tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    pkg-config \
+    cmake \
+    clang \
+    llvm-dev \
+    libclang-dev \
+    libssl-dev \
+    libfuse3-dev \
+    vim \
+    less \
+    jq \
+    htop \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust toolchain
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN} \
+    && . $HOME/.cargo/env \
+    && rustup component add rustfmt clippy rust-analyzer
+
+# Set Rust environment
+ENV PATH="/root/.cargo/bin:${PATH}" \
+    CARGO_HOME="/root/.cargo" \
+    RUSTUP_HOME="/root/.rustup"
+
+# Install additional Cargo tools
+RUN cargo install cargo-watch cargo-expand
+
+LABEL mega.image.type="dev"

--- a/docker/dev-image/README.md
+++ b/docker/dev-image/README.md
@@ -1,0 +1,395 @@
+# Mega Dev Image (Client Toolchain) - Development and Testing Guide
+
+## Table of Contents
+
+- [Image Overview](#image-overview)
+- [Quick Start](#quick-start)
+- [Image Build](#image-build)
+- [Image Testing](#image-testing)
+- [Configuration](#configuration)
+- [Service Usage](#service-usage)
+- [Development Workflow Examples](#development-workflow-examples)
+- [Platform Compatibility](#platform-compatibility)
+- [FAQ](#faq)
+
+---
+
+## Image Overview
+
+Mega Dev Image is a unified Linux development image that packages the **client-side** tooling used in the Mega build pipeline:
+
+| Component | Description | Purpose |
+|-----------|-------------|---------|
+| **Orion Worker (`orion`)** | Build execution client | Connects to an external Orion Server, mounts workspace via Scorpio, runs Buck2 |
+| **Scorpio (`scorpio`)** | FUSE filesystem daemon | Virtual filesystem mounting / Build workspace support |
+| **Buck2 (`buck2`)** | Build tool | High-performance incremental builds |
+
+This image intentionally does **not** start Orion Server or PostgreSQL. It is designed for:
+- Linux developers doing local mounting + Buck2 debugging
+- macOS/Windows developers using a remote Linux server as a consistent test environment
+- CI and automated checks that only need worker/scorpio/buck2 tooling
+
+### Image Tags
+
+| Tag | Description | Use Case |
+|-----|-------------|----------|
+| `mega-dev:latest` / `mega-dev:runtime` | Minimal runtime image | CI/CD, remote tooling |
+| `mega-dev:dev` | Development image (includes Rust toolchain) | Local development and debugging |
+
+### Supported Architectures
+
+- `linux/amd64` (x86_64)
+- `linux/arm64` (aarch64)
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+- Docker 20.10+ or Podman 4.0+
+- Linux host (Scorpio needs FUSE; macOS/Windows requires remote Linux server)
+- `jq` (recommended for parsing JSON responses)
+
+### 1) Build the Image
+
+```bash
+cd /path/to/mega
+
+docker build -t mega-dev:latest \
+  --target runtime \
+  --build-arg GIT_COMMIT=$(git rev-parse HEAD) \
+  --build-arg BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+  -f docker/dev-image/Dockerfile .
+```
+
+### 2) Start Scorpio (Docker Compose)
+
+```bash
+# Start Scorpio daemon (requires FUSE)
+docker run -d --name scorpio \
+  --privileged \
+  -p 2725:2725 \
+  -e SCORPIO_BASE_URL=http://host.docker.internal:8000 \
+  -e SCORPIO_LFS_URL=http://host.docker.internal:8000 \
+  mega-dev:latest scorpio
+
+# Check health
+curl -s http://localhost:2725/antares/health
+```
+
+### 3) Mount a Repo and Run Buck2 (inside Scorpio container)
+
+Scorpio needs Mono (Mega main service) to fetch repository content. Ensure `SCORPIO_BASE_URL` points to a reachable Mono service.
+
+```bash
+export REPO_PATH="your/real/repo/path"
+
+# Create mount (returns mountpoint)
+MOUNTPOINT=$(curl -s -X POST http://localhost:2725/antares/mounts \
+  -H "Content-Type: application/json" \
+  -d "{\"path\":\"${REPO_PATH}\",\"job_id\":\"manual-test\"}" | jq -r '.mountpoint')
+
+echo "Mountpoint: ${MOUNTPOINT}"
+
+# Run Buck2 inside the same container namespace as the mount
+docker exec scorpio bash -lc "cd '${MOUNTPOINT}' && buck2 --version && buck2 build //..."
+```
+
+### 4) (Optional) Start Orion Worker
+
+Orion Worker connects to an external Orion Server WebSocket endpoint (`SERVER_WS`). If no Orion Server is available, the worker will keep retrying the connection.
+
+```bash
+docker run -d --name orion-worker \
+  --privileged \
+  -e SERVER_WS=ws://your-orion-server:8004/ws \
+  -e SCORPIO_BASE_URL=http://host.docker.internal:8000 \
+  mega-dev:latest orion
+
+docker logs -f orion-worker
+```
+
+---
+
+## Image Build
+
+### Build Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `RUST_VERSION` | `1.92-bookworm` | Rust builder base image tag |
+| `RUST_TOOLCHAIN` | `1.92.0` | dev image rustup toolchain |
+| `BUCK2_VERSION` | `2025-06-01` | Buck2 release version (GitHub release tag) |
+| `GIT_COMMIT` | `unknown` | Git commit hash (written to image LABEL) |
+| `BUILD_DATE` | `unknown` | Build date (ISO 8601 format) |
+
+### Multi-Architecture Build
+
+```bash
+docker buildx create --name mega-builder --use
+
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  --target runtime \
+  --build-arg GIT_COMMIT=$(git rev-parse HEAD) \
+  --build-arg BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+  -t mega-dev:latest \
+  -f docker/dev-image/Dockerfile \
+  --push .
+```
+
+---
+
+## Image Testing
+
+### 1) Basic Validation (No FUSE Required)
+
+```bash
+docker run --rm mega-dev:latest version
+docker run --rm mega-dev:latest buck2 --version
+docker run --rm mega-dev:latest bash -lc "command -v scorpio && command -v orion"
+```
+
+### 2) Scorpio Validation (Requires FUSE)
+
+```bash
+docker run -d --name scorpio \
+  --privileged \
+  -p 2725:2725 \
+  -e SCORPIO_BASE_URL=http://host.docker.internal:8000 \
+  -e SCORPIO_LFS_URL=http://host.docker.internal:8000 \
+  mega-dev:latest scorpio
+
+curl -s http://localhost:2725/antares/health
+```
+
+### 3) End-to-End Validation: Scorpio + Mono + Buck2 (Requires FUSE + Mono)
+
+```bash
+export REPO_PATH="your/real/repo/path"
+
+MOUNTPOINT=$(curl -s -X POST http://localhost:2725/antares/mounts \
+  -H "Content-Type: application/json" \
+  -d "{\"path\":\"${REPO_PATH}\",\"job_id\":\"smoke\"}" | jq -r '.mountpoint')
+
+docker exec scorpio bash -lc "cd '${MOUNTPOINT}' && buck2 build //..."
+```
+
+---
+
+## Configuration
+
+### Scorpio Configuration
+
+Scorpio uses a `scorpio.toml` configuration file; the built-in template supports environment variable substitution.
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `SCORPIO_BASE_URL` | `http://localhost:8000` | Mono service address (required for mounts) |
+| `SCORPIO_LFS_URL` | `http://localhost:8000` | LFS service address |
+| `SCORPIO_STORE_PATH` | `/data/scorpio/store` | Data storage path |
+| `SCORPIO_WORKSPACE` | `/workspace/mount` | Workspace mount root |
+| `SCORPIO_GIT_AUTHOR` | `MEGA` | Git author name |
+| `SCORPIO_GIT_EMAIL` | `admin@mega.org` | Git email |
+
+Custom configuration file:
+
+```bash
+docker run -d --name scorpio \
+  --privileged \
+  -v /path/to/scorpio.toml:/app/config/scorpio.toml:ro \
+  -p 2725:2725 \
+  mega-dev:latest scorpio -c /app/config/scorpio.toml
+```
+
+### Orion Worker Configuration
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `SERVER_WS` | `ws://127.0.0.1:8004/ws` | Orion Server WebSocket URL (external) |
+| `ORION_WORKER_ID` | - | Optional worker id (generated if not set) |
+| `BUCK_PROJECT_ROOT` | `/workspace` | Root dir that contains the Scorpio mount dir `mount/` |
+| `BUILD_TMP` | `/tmp/orion-builds` | Worker temp/build directory |
+| `SCORPIO_API_BASE_URL` | `http://localhost:2725` | Scorpio API base URL used by worker |
+| `ORION_WORKER_START_SCORPIO` | `true` | Whether to start embedded Scorpio inside worker container |
+
+---
+
+## Service Usage
+
+### Scorpio
+
+#### Dependency Notes
+
+- Scorpio requires a running Mono service to fetch repository content (configure `SCORPIO_BASE_URL`).
+- Scorpio requires FUSE support and container privileges (see FAQ).
+
+#### Start Service
+
+```bash
+docker run -d --name scorpio \
+  --privileged \
+  -e SCORPIO_BASE_URL=http://host.docker.internal:8000 \
+  -p 2725:2725 \
+  mega-dev:latest scorpio
+```
+
+#### Mount a Repo (Antares API)
+
+```bash
+curl -s -X POST http://localhost:2725/antares/mounts \
+  -H "Content-Type: application/json" \
+  -d '{"path":"your/real/repo/path","job_id":"manual-test"}' | jq
+```
+
+### Buck2
+
+```bash
+docker run --rm mega-dev:latest buck2 --version
+```
+
+When building from a Scorpio mount, run Buck2 inside the Scorpio container:
+
+```bash
+docker exec scorpio bash -lc "cd /workspace/mount && buck2 build //..."
+```
+
+### Orion Worker
+
+Orion Worker connects to an external Orion Server. It does not expose an HTTP API.
+
+```bash
+docker run -d --name orion-worker \
+  --privileged \
+  -e SERVER_WS=ws://your-orion-server:8004/ws \
+  -e SCORPIO_BASE_URL=http://host.docker.internal:8000 \
+  mega-dev:latest orion
+```
+
+---
+
+## Development Workflow Examples
+
+### Example 1: Scorpio Mount + Buck2 Build
+
+```bash
+docker run -d --name scorpio \
+  --privileged \
+  -p 2725:2725 \
+  -e SCORPIO_BASE_URL=http://host.docker.internal:8000 \
+  -e SCORPIO_LFS_URL=http://host.docker.internal:8000 \
+  mega-dev:latest scorpio
+
+export REPO_PATH="your/real/repo/path"
+MOUNTPOINT=$(curl -s -X POST http://localhost:2725/antares/mounts \
+  -H "Content-Type: application/json" \
+  -d "{\"path\":\"${REPO_PATH}\",\"job_id\":\"example\"}" | jq -r '.mountpoint')
+
+docker exec scorpio bash -lc "cd '${MOUNTPOINT}' && buck2 build //..."
+```
+
+### Example 2: Buck2 Debugging on a Local Workspace (No Scorpio)
+
+```bash
+docker run -it --rm \
+  -v $(pwd):/workspace \
+  -w /workspace \
+  mega-dev:latest bash
+
+# inside container
+buck2 --version
+```
+
+### Example 3: Run Orion Worker Against a Remote Orion Server
+
+```bash
+docker run -d --name orion-worker \
+  --privileged \
+  -e SERVER_WS=ws://your-orion-server:8004/ws \
+  -e SCORPIO_BASE_URL=http://host.docker.internal:8000 \
+  mega-dev:latest orion
+
+docker logs -f orion-worker
+```
+
+---
+
+## Platform Compatibility
+
+### Linux (Full Support)
+
+- Scorpio FUSE mount
+- Buck2 build
+- Orion Worker (connect to external server)
+
+### macOS / Windows (Partial Support)
+
+Due to FUSE and kernel differences, Scorpio cannot run locally on macOS/Windows.
+
+Recommended approach:
+- Run this image on a remote Linux server
+- Use SSH port forwarding to access Scorpio API
+
+```bash
+ssh -L 2725:localhost:2725 user@remote-server
+```
+
+---
+
+## FAQ
+
+### Q1: Scorpio startup fails with "/dev/fuse not found"
+
+Cause: container does not have access to the FUSE device.
+
+```bash
+# Recommended
+docker run --privileged ...
+
+# Minimal privilege mode
+docker run \
+  --device /dev/fuse \
+  --cap-add SYS_ADMIN \
+  --security-opt apparmor:unconfined \
+  ...
+```
+
+### Q2: Scorpio mount fails / cannot fetch repository content
+
+Cause: Scorpio requires Mono service to fetch tree/blob/commit data, but `SCORPIO_BASE_URL` is not reachable or incorrect.
+
+Action:
+- Ensure Mono is running and reachable from the container
+- Set `SCORPIO_BASE_URL` / `SCORPIO_LFS_URL` accordingly (see `.env.example`)
+
+### Q3: Buck2 build fails with missing `//third-party:*`
+
+Cause: BUCK files depend on `//third-party:*`, but the `third-party` directory may need to be generated via Reindeer.
+
+```bash
+cargo install --locked --git https://github.com/facebookincubator/reindeer reindeer
+reindeer buckify
+```
+
+### Q4: Mountpoint not visible in another container
+
+Cause: FUSE mountpoints are tied to a container's mount namespace.
+
+Action:
+- Run `buck2` via `docker exec` inside the `scorpio` container, or
+- Run Scorpio embedded in the same container as the process that consumes the mount.
+
+---
+
+## File Structure
+
+```
+docker/dev-image/
+├── Dockerfile              # Multi-stage build file
+├── docker-compose.yml      # Optional orchestration (scorpio/worker/dev)
+├── entrypoint.sh           # Container entrypoint script
+├── scorpio.toml.template   # Scorpio configuration template
+├── .env.example            # Environment variable example
+└── README.md               # This document
+```

--- a/docker/dev-image/docker-compose.yml
+++ b/docker/dev-image/docker-compose.yml
@@ -1,0 +1,119 @@
+# =============================================================================
+# Mega Dev Image - Docker Compose (Client Toolchain)
+# =============================================================================
+# This compose file provides a lightweight environment for:
+# - Scorpio (FUSE filesystem daemon + HTTP API)
+# - Orion Worker (optional; connects to an external Orion Server)
+# - Buck2 tooling (available in the image; typically run via `docker exec` into scorpio)
+#
+# Notes:
+# - Orion Server is NOT started here. Configure `SERVER_WS` to point to your Orion Server.
+# - Scorpio performs real mounts and therefore requires Linux FUSE support.
+#
+# Profiles:
+#   dev     - Interactive development shell (tooling only)
+#   fuse    - Scorpio daemon (requires privileged mode)
+#   worker  - Orion Worker (requires privileged mode; embeds Scorpio by default)
+# =============================================================================
+
+services:
+  # ---------------------------------------------------------------------------
+  # Scorpio - FUSE Filesystem Service (daemon)
+  # ---------------------------------------------------------------------------
+  scorpio:
+    image: ${MEGA_DEV_IMAGE:-mega-dev:latest}
+    container_name: mega-scorpio
+    command: scorpio
+    profiles:
+      - fuse
+    privileged: true
+    environment:
+      SCORPIO_BASE_URL: ${SCORPIO_BASE_URL:-http://host.docker.internal:8000}
+      SCORPIO_LFS_URL: ${SCORPIO_LFS_URL:-http://host.docker.internal:8000}
+      SCORPIO_STORE_PATH: /data/scorpio/store
+      SCORPIO_WORKSPACE: /workspace/mount
+      SCORPIO_GIT_AUTHOR: ${SCORPIO_GIT_AUTHOR:-MEGA}
+      SCORPIO_GIT_EMAIL: ${SCORPIO_GIT_EMAIL:-admin@mega.org}
+      RUST_LOG: ${RUST_LOG:-info}
+    ports:
+      - "${SCORPIO_PORT:-2725}:2725"
+    volumes:
+      - scorpio-data:/data/scorpio
+      - workspace:/workspace
+    restart: unless-stopped
+    networks:
+      - mega-network
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  # ---------------------------------------------------------------------------
+  # Orion Worker - Build Execution Client (optional)
+  # ---------------------------------------------------------------------------
+  # The worker can run without an Orion Server, but it will keep retrying the
+  # WebSocket connection and won't execute builds until tasks are assigned.
+  orion-worker:
+    image: ${MEGA_DEV_IMAGE:-mega-dev:latest}
+    container_name: mega-orion-worker
+    command: orion
+    profiles:
+      - worker
+    privileged: true
+    environment:
+      SERVER_WS: ${SERVER_WS:-ws://host.docker.internal:8004/ws}
+      ORION_WORKER_ID: ${ORION_WORKER_ID:-}
+      BUCK_PROJECT_ROOT: ${BUCK_PROJECT_ROOT:-/workspace}
+      BUILD_TMP: ${BUILD_TMP:-/tmp/orion-builds}
+      SCORPIO_API_BASE_URL: ${SCORPIO_API_BASE_URL:-http://127.0.0.1:2725}
+      ORION_WORKER_START_SCORPIO: ${ORION_WORKER_START_SCORPIO:-true}
+      SCORPIO_BASE_URL: ${SCORPIO_BASE_URL:-http://host.docker.internal:8000}
+      SCORPIO_LFS_URL: ${SCORPIO_LFS_URL:-http://host.docker.internal:8000}
+      SCORPIO_STORE_PATH: /data/scorpio/store
+      SCORPIO_WORKSPACE: /workspace/mount
+      RUST_LOG: ${RUST_LOG:-info}
+    volumes:
+      - scorpio-data:/data/scorpio
+      - workspace:/workspace
+    restart: unless-stopped
+    networks:
+      - mega-network
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  # ---------------------------------------------------------------------------
+  # Development Shell - Tooling Only
+  # ---------------------------------------------------------------------------
+  dev:
+    image: ${MEGA_DEV_IMAGE:-mega-dev:dev}
+    container_name: mega-dev-shell
+    profiles:
+      - dev
+    privileged: true
+    environment:
+      RUST_LOG: ${RUST_LOG:-debug}
+    volumes:
+      - ../..:/workspace
+      - scorpio-data:/data/scorpio
+      - cargo-cache:/root/.cargo/registry
+      - target-cache:/workspace/target
+    working_dir: /workspace
+    stdin_open: true
+    tty: true
+    networks:
+      - mega-network
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+volumes:
+  scorpio-data:
+    name: mega-scorpio-data
+  workspace:
+    name: mega-workspace
+  cargo-cache:
+    name: mega-cargo-cache
+  target-cache:
+    name: mega-target-cache
+
+networks:
+  mega-network:
+    name: mega-network
+

--- a/docker/dev-image/entrypoint.sh
+++ b/docker/dev-image/entrypoint.sh
@@ -1,0 +1,358 @@
+#!/bin/bash
+# =============================================================================
+# Mega Dev Image - Entrypoint Script
+# =============================================================================
+# This script handles container startup for different services:
+# - orion: Start the Orion worker (build execution client)
+# - scorpio: Start the Scorpio FUSE filesystem service (daemon)
+# - buck2: Run Buck2 commands
+# - bash/sh: Interactive shell
+# - help: Show usage information
+# =============================================================================
+
+set -e
+
+# -----------------------------------------------------------------------------
+# Configuration
+# -----------------------------------------------------------------------------
+CONFIG_DIR="/app/config"
+SCORPIO_CONFIG="/app/config/scorpio.toml"
+SCORPIO_TEMPLATE="/app/config/scorpio.toml.template"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# -----------------------------------------------------------------------------
+# Helper Functions
+# -----------------------------------------------------------------------------
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_header() {
+    echo -e "${BLUE}============================================================${NC}"
+    echo -e "${BLUE} $1${NC}"
+    echo -e "${BLUE}============================================================${NC}"
+}
+
+show_help() {
+    cat << 'EOF'
+Mega Dev Image - Unified Development Environment
+=================================================
+
+Usage: docker run [OPTIONS] mega-dev:<tag> <COMMAND> [ARGS...]
+
+Commands:
+  orion           Start the Orion worker (build execution client)
+  orion-worker    Alias for `orion`
+  scorpio         Start the Scorpio FUSE filesystem service
+  buck2 [ARGS]    Run Buck2 with specified arguments
+  bash, sh        Start an interactive shell
+  help            Show this help message
+
+Examples:
+  # Start Scorpio (requires privileged mode for FUSE)
+  docker run -d --name scorpio \
+    --privileged \
+    -e SCORPIO_BASE_URL=http://mega-server:8000 \
+    -p 2725:2725 \
+    mega-dev:latest scorpio
+
+  # Mount repo and run Buck2 (mountpoints are visible only inside the Scorpio container)
+  #   MOUNTPOINT=$(curl -s -X POST http://localhost:2725/antares/mounts \
+  #     -H "Content-Type: application/json" \
+  #     -d '{"path":"your/real/repo/path","job_id":"manual"}' | jq -r '.mountpoint')
+  #   docker exec scorpio bash -lc "cd '${MOUNTPOINT}' && buck2 build //..."
+
+  # Start Orion Worker (includes Buck2 execution; typically needs Scorpio + FUSE)
+  docker run -d --name orion-worker \
+    --privileged \
+    -e SERVER_WS=ws://your-orion-server:8004/ws \
+    -e SCORPIO_BASE_URL=http://mega-server:8000 \
+    mega-dev:latest orion
+
+  # Run Buck2 build
+  docker run --rm -v $(pwd):/workspace mega-dev:latest buck2 build //...
+
+  # Interactive development
+  docker run -it --rm -v $(pwd):/workspace mega-dev:dev bash
+
+Environment Variables:
+  See .env.example for full list of configurable options.
+
+For more information, see the README.md in docker/dev-image/
+EOF
+}
+
+# Generate Scorpio config from template
+generate_scorpio_config() {
+    log_info "Generating Scorpio configuration..."
+
+    if [ -f "$SCORPIO_TEMPLATE" ]; then
+        # Defaults (must be set before envsubst; it does not support "${VAR:-default}" syntax)
+        : "${SCORPIO_BASE_URL:=http://host.docker.internal:8000}"
+        : "${SCORPIO_LFS_URL:=${SCORPIO_BASE_URL}}"
+        : "${SCORPIO_STORE_PATH:=/data/scorpio/store}"
+        : "${SCORPIO_WORKSPACE:=/workspace/mount}"
+        : "${SCORPIO_GIT_AUTHOR:=MEGA}"
+        : "${SCORPIO_GIT_EMAIL:=admin@mega.org}"
+        : "${SCORPIO_DICFUSE_READABLE:=true}"
+        : "${SCORPIO_LOAD_DIR_DEPTH:=3}"
+        : "${SCORPIO_FETCH_FILE_THREAD:=10}"
+        : "${SCORPIO_DICFUSE_IMPORT_CONCURRENCY:=4}"
+        : "${SCORPIO_DICFUSE_DIR_SYNC_TTL_SECS:=5}"
+        : "${SCORPIO_DICFUSE_STAT_MODE:=accurate}"
+        : "${SCORPIO_DICFUSE_OPEN_BUFF_MAX_BYTES:=268435456}"
+        : "${SCORPIO_DICFUSE_OPEN_BUFF_MAX_FILES:=4096}"
+
+        : "${ANTARES_LOAD_DIR_DEPTH:=0}"
+        : "${ANTARES_DICFUSE_STAT_MODE:=fast}"
+        : "${ANTARES_DICFUSE_OPEN_BUFF_MAX_BYTES:=67108864}"
+        : "${ANTARES_DICFUSE_OPEN_BUFF_MAX_FILES:=1024}"
+        : "${ANTARES_DICFUSE_DIR_SYNC_TTL_SECS:=5}"
+        : "${ANTARES_UPPER_ROOT:=/data/scorpio/antares/upper}"
+        : "${ANTARES_CL_ROOT:=/data/scorpio/antares/cl}"
+        : "${ANTARES_MOUNT_ROOT:=/data/scorpio/antares/mnt}"
+        : "${ANTARES_STATE_FILE:=/data/scorpio/antares/state.toml}"
+
+        export \
+            SCORPIO_BASE_URL \
+            SCORPIO_LFS_URL \
+            SCORPIO_STORE_PATH \
+            SCORPIO_WORKSPACE \
+            SCORPIO_GIT_AUTHOR \
+            SCORPIO_GIT_EMAIL \
+            SCORPIO_DICFUSE_READABLE \
+            SCORPIO_LOAD_DIR_DEPTH \
+            SCORPIO_FETCH_FILE_THREAD \
+            SCORPIO_DICFUSE_IMPORT_CONCURRENCY \
+            SCORPIO_DICFUSE_DIR_SYNC_TTL_SECS \
+            SCORPIO_DICFUSE_STAT_MODE \
+            SCORPIO_DICFUSE_OPEN_BUFF_MAX_BYTES \
+            SCORPIO_DICFUSE_OPEN_BUFF_MAX_FILES \
+            ANTARES_LOAD_DIR_DEPTH \
+            ANTARES_DICFUSE_STAT_MODE \
+            ANTARES_DICFUSE_OPEN_BUFF_MAX_BYTES \
+            ANTARES_DICFUSE_OPEN_BUFF_MAX_FILES \
+            ANTARES_DICFUSE_DIR_SYNC_TTL_SECS \
+            ANTARES_UPPER_ROOT \
+            ANTARES_CL_ROOT \
+            ANTARES_MOUNT_ROOT \
+            ANTARES_STATE_FILE
+
+        # Use envsubst to replace environment variables in template
+        envsubst < "$SCORPIO_TEMPLATE" > "$SCORPIO_CONFIG"
+        log_info "Scorpio config generated at: $SCORPIO_CONFIG"
+    else
+        log_warn "Scorpio template not found at $SCORPIO_TEMPLATE"
+    fi
+}
+
+# Wait for a TCP service to be available
+wait_for_service() {
+    local host=$1
+    local port=$2
+    local timeout=${3:-30}
+    local elapsed=0
+
+    log_info "Waiting for $host:$port (timeout: ${timeout}s)..."
+
+    while ! nc -z "$host" "$port" 2>/dev/null; do
+        sleep 1
+        elapsed=$((elapsed + 1))
+        if [ $elapsed -ge $timeout ]; then
+            log_error "Timeout waiting for $host:$port"
+            return 1
+        fi
+    done
+
+    log_info "$host:$port is available"
+    return 0
+}
+
+# Create required directories
+setup_directories() {
+    log_info "Setting up directories..."
+
+    mkdir -p "${SCORPIO_STORE_PATH:-/data/scorpio/store}"
+    mkdir -p "${SCORPIO_WORKSPACE:-/workspace/mount}"
+    mkdir -p "${ANTARES_UPPER_ROOT:-/data/scorpio/antares/upper}"
+    mkdir -p "${ANTARES_CL_ROOT:-/data/scorpio/antares/cl}"
+    mkdir -p "${ANTARES_MOUNT_ROOT:-/data/scorpio/antares/mnt}"
+}
+
+# Check FUSE availability for Scorpio
+check_fuse() {
+    if [ ! -e /dev/fuse ]; then
+        log_error "/dev/fuse not found!"
+        log_error "Scorpio requires FUSE support. Please run the container with:"
+        log_error "  --privileged"
+        log_error "  or: --device /dev/fuse --cap-add SYS_ADMIN"
+        exit 1
+    fi
+    log_info "FUSE device available"
+}
+
+# Print version information
+print_versions() {
+    log_header "Mega Dev Image - Version Information"
+    echo ""
+    echo "Components:"
+    if command -v orion &>/dev/null; then
+        echo "  Orion Worker: installed"
+    else
+        echo "  Orion Worker: missing"
+    fi
+    if command -v scorpio &>/dev/null; then
+        echo "  Scorpio:      installed"
+    else
+        echo "  Scorpio:      missing"
+    fi
+    echo "  Buck2:        $(buck2 --version 2>/dev/null || echo 'unknown')"
+    echo ""
+    echo "Image Labels:"
+    if [ -f /etc/mega-image-info ]; then
+        cat /etc/mega-image-info
+    fi
+    echo ""
+}
+
+# -----------------------------------------------------------------------------
+# Service Start Functions
+# -----------------------------------------------------------------------------
+
+start_scorpio() {
+    log_header "Starting Scorpio"
+
+    print_versions
+    check_fuse
+    setup_directories
+    generate_scorpio_config
+
+    log_info "Configuration:"
+    echo "  BASE_URL: ${SCORPIO_BASE_URL:-http://localhost:8000}"
+    echo "  STORE_PATH: ${SCORPIO_STORE_PATH:-/data/scorpio/store}"
+    echo "  WORKSPACE: ${SCORPIO_WORKSPACE:-/workspace/mount}"
+    echo ""
+
+    log_info "Starting scorpio..."
+    exec scorpio -c "$SCORPIO_CONFIG" "$@"
+}
+
+start_orion_worker() {
+    log_header "Starting Orion Worker"
+
+    print_versions
+
+    # Orion worker configuration
+    : "${SERVER_WS:=ws://127.0.0.1:8004/ws}"
+    : "${BUCK_PROJECT_ROOT:=/workspace}"
+    : "${BUILD_TMP:=/tmp/orion-builds}"
+    : "${SCORPIO_API_BASE_URL:=http://127.0.0.1:2725}"
+    : "${ORION_WORKER_START_SCORPIO:=true}"
+
+    setup_directories
+    mkdir -p "${BUILD_TMP}"
+
+    # Most workflows require Scorpio to run in the same container namespace as the worker,
+    # so the mounted Antares/FUSE mount points are accessible to Buck2.
+    if [ "${ORION_WORKER_START_SCORPIO}" != "false" ] && [ "${ORION_WORKER_START_SCORPIO}" != "0" ]; then
+        log_info "Starting embedded Scorpio for worker..."
+        check_fuse
+        generate_scorpio_config
+
+        # Ensure the worker talks to the embedded Scorpio by default.
+        export SCORPIO_API_BASE_URL="http://127.0.0.1:2725"
+
+        scorpio -c "$SCORPIO_CONFIG" &
+        local scorpio_pid=$!
+
+        cleanup() {
+            if kill -0 "${scorpio_pid}" 2>/dev/null; then
+                log_info "Stopping embedded Scorpio (pid=${scorpio_pid})..."
+                kill "${scorpio_pid}" 2>/dev/null || true
+            fi
+        }
+
+        trap cleanup EXIT INT TERM
+
+        wait_for_service "127.0.0.1" "2725" 60 || exit 1
+    else
+        log_warn "ORION_WORKER_START_SCORPIO disabled; ensure Scorpio mountpoints are accessible to this container."
+    fi
+
+    log_info "Configuration:"
+    echo "  SERVER_WS: ${SERVER_WS}"
+    echo "  ORION_WORKER_ID: ${ORION_WORKER_ID:-(auto)}"
+    echo "  BUCK_PROJECT_ROOT: ${BUCK_PROJECT_ROOT}"
+    echo "  BUILD_TMP: ${BUILD_TMP}"
+    echo "  SCORPIO_API_BASE_URL: ${SCORPIO_API_BASE_URL}"
+    echo "  SCORPIO_BASE_URL: ${SCORPIO_BASE_URL:-(not set)}"
+    echo ""
+
+    log_info "Starting orion worker..."
+    exec orion "$@"
+}
+
+run_buck2() {
+    log_info "Running Buck2..."
+    exec buck2 "$@"
+}
+
+# -----------------------------------------------------------------------------
+# Main Entry Point
+# -----------------------------------------------------------------------------
+
+main() {
+    local command="${1:-help}"
+    shift 2>/dev/null || true
+
+    case "$command" in
+        orion|orion-worker)
+            start_orion_worker "$@"
+            ;;
+        scorpio)
+            start_scorpio "$@"
+            ;;
+        buck2)
+            run_buck2 "$@"
+            ;;
+        bash|sh)
+            print_versions
+            exec /bin/bash "$@"
+            ;;
+        version|--version|-v)
+            print_versions
+            ;;
+        help|--help|-h)
+            show_help
+            ;;
+        *)
+            # If the command is an executable, run it directly
+            if command -v "$command" &>/dev/null; then
+                exec "$command" "$@"
+            else
+                log_error "Unknown command: $command"
+                echo ""
+                show_help
+                exit 1
+            fi
+            ;;
+    esac
+}
+
+# Run main function
+main "$@"

--- a/docker/dev-image/entrypoint.sh
+++ b/docker/dev-image/entrypoint.sh
@@ -318,7 +318,7 @@ run_buck2() {
 
 main() {
     local command="${1:-help}"
-    shift 2>/dev/null || true
+    shift 1 2>/dev/null || true
 
     case "$command" in
         orion|orion-worker)

--- a/docker/dev-image/scorpio.toml.template
+++ b/docker/dev-image/scorpio.toml.template
@@ -1,0 +1,40 @@
+# =============================================================================
+# Scorpio Configuration Template
+# =============================================================================
+# This template uses simple environment variable placeholders like `${VAR_NAME}`.
+# The entrypoint script sets defaults and then substitutes the variables via `envsubst`.
+# =============================================================================
+
+# Mega/Mono service URLs
+base_url = "${SCORPIO_BASE_URL}"
+lfs_url = "${SCORPIO_LFS_URL}"
+
+# Storage paths
+store_path = "${SCORPIO_STORE_PATH}"
+workspace = "${SCORPIO_WORKSPACE}"
+config_file = "config.toml"
+
+# Git author configuration
+git_author = "${SCORPIO_GIT_AUTHOR}"
+git_email = "${SCORPIO_GIT_EMAIL}"
+
+# DicFuse (dictionary-based FUSE) settings
+dicfuse_readable = "${SCORPIO_DICFUSE_READABLE}"
+load_dir_depth = "${SCORPIO_LOAD_DIR_DEPTH}"
+fetch_file_thread = "${SCORPIO_FETCH_FILE_THREAD}"
+dicfuse_import_concurrency = "${SCORPIO_DICFUSE_IMPORT_CONCURRENCY}"
+dicfuse_dir_sync_ttl_secs = "${SCORPIO_DICFUSE_DIR_SYNC_TTL_SECS}"
+dicfuse_stat_mode = "${SCORPIO_DICFUSE_STAT_MODE}"
+dicfuse_open_buff_max_bytes = "${SCORPIO_DICFUSE_OPEN_BUFF_MAX_BYTES}"
+dicfuse_open_buff_max_files = "${SCORPIO_DICFUSE_OPEN_BUFF_MAX_FILES}"
+
+# Antares (overlay filesystem) settings
+antares_load_dir_depth = "${ANTARES_LOAD_DIR_DEPTH}"
+antares_dicfuse_stat_mode = "${ANTARES_DICFUSE_STAT_MODE}"
+antares_dicfuse_open_buff_max_bytes = "${ANTARES_DICFUSE_OPEN_BUFF_MAX_BYTES}"
+antares_dicfuse_open_buff_max_files = "${ANTARES_DICFUSE_OPEN_BUFF_MAX_FILES}"
+antares_dicfuse_dir_sync_ttl_secs = "${ANTARES_DICFUSE_DIR_SYNC_TTL_SECS}"
+antares_upper_root = "${ANTARES_UPPER_ROOT}"
+antares_cl_root = "${ANTARES_CL_ROOT}"
+antares_mount_root = "${ANTARES_MOUNT_ROOT}"
+antares_state_file = "${ANTARES_STATE_FILE}"

--- a/orion-server/src/log/log_service.rs
+++ b/orion-server/src/log/log_service.rs
@@ -19,6 +19,7 @@ pub struct LogService {
     tx: tokio::sync::broadcast::Sender<LogEvent>,
     local_log_store: Arc<dyn LogStore>,
     cloud_log_store: Arc<dyn LogStore>,
+    cloud_upload_enabled: bool,
 }
 
 impl LogService {
@@ -26,6 +27,7 @@ impl LogService {
         local_log_store: Arc<dyn LogStore>,
         cloud_log_store: Arc<dyn LogStore>,
         buffer: usize,
+        cloud_upload_enabled: bool,
     ) -> Self {
         let (tx, _rx) = tokio::sync::broadcast::channel(buffer);
 
@@ -33,6 +35,7 @@ impl LogService {
             tx,
             local_log_store,
             cloud_log_store,
+            cloud_upload_enabled,
         }
     }
 
@@ -145,7 +148,7 @@ impl LogService {
                         );
                     }
 
-                    if event.is_end {
+                    if event.is_end && self.cloud_upload_enabled {
                         let key = self.cloud_log_store.get_key(
                             &event.task_id,
                             &event.repo_name,

--- a/orion-server/src/log/store/mod.rs
+++ b/orion-server/src/log/store/mod.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 
 pub mod local_log_store;
+pub mod noop_log_store;
 pub mod s3_log_store;
 
 /// Trait representing a generic log storage backend.

--- a/orion-server/src/log/store/noop_log_store.rs
+++ b/orion-server/src/log/store/noop_log_store.rs
@@ -1,0 +1,35 @@
+use anyhow::{Result, bail};
+
+use crate::log::store::LogStore;
+
+#[derive(Debug, Default)]
+pub struct NoopLogStore;
+
+impl NoopLogStore {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait::async_trait]
+impl LogStore for NoopLogStore {
+    async fn append(&self, _key: &str, _data: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn read(&self, key: &str) -> Result<String> {
+        bail!("log storage disabled for key: {}", key)
+    }
+
+    async fn delete(&self, _key: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn read_range(&self, key: &str, _start_line: usize, _end_line: usize) -> Result<String> {
+        bail!("log storage disabled for key: {}", key)
+    }
+
+    async fn log_exists(&self, _key: &str) -> bool {
+        false
+    }
+}

--- a/orion-server/src/server.rs
+++ b/orion-server/src/server.rs
@@ -99,6 +99,13 @@ pub async fn init_log_service() -> LogService {
         ),
     };
 
+    tracing::info!(
+        storage_type = %log_store_type,
+        cloud_upload_enabled,
+        build_log_dir = %build_log_dir,
+        "Initialized log service storage configuration"
+    );
+
     // Create the LogService
     LogService::new(
         local_log_store,

--- a/orion/src/buck_controller.rs
+++ b/orion/src/buck_controller.rs
@@ -521,7 +521,8 @@ pub async fn build(
     // Directly mount the entire repository, starting from the root directory /,
     // to analyze changes and determine what needs to be built.
     // Handle empty cl string as None to mount the base repo without a CL layer.
-    let cl_arg = (!cl.trim().is_empty()).then_some(cl.as_str());
+    let cl_trimmed = cl.trim();
+    let cl_arg = (!cl_trimmed.is_empty()).then_some(cl_trimmed);
     let (mount_point, mount_id) = mount_antares_fs(&id, "/", cl_arg).await?;
     let _mount_guard = MountGuard::new(mount_id.clone(), id.clone());
 

--- a/orion/src/fs.rs
+++ b/orion/src/fs.rs
@@ -87,7 +87,7 @@ pub async fn mount_fs(repo: &str, mr: &str) -> Result<bool, Box<dyn Error + Send
         sleep(Duration::from_secs(poll_interval)).await;
         poll_interval = std::cmp::min(poll_interval * 2, max_poll_interval_secs);
 
-        let select_url = format!("{}/api/fs/select/{request_id}", scorpio_base_url());
+        let select_url = format!("{base}/api/fs/select/{request_id}");
         let select_res = client.get(&select_url).send().await?;
         let select_body: Value = select_res.json().await?;
 

--- a/orion/src/fs.rs
+++ b/orion/src/fs.rs
@@ -4,6 +4,10 @@ use serde_json::{Value, json};
 use std::{error::Error, fs, path::{Path, PathBuf}, process::Command, time::{SystemTime, UNIX_EPOCH}};
 use tokio::{time::{sleep, Duration}};
 
+fn scorpio_base_url() -> String {
+    crate::scorpio_api::base_url()
+}
+
 /// The directory this module use to store data, mount repo, build target.
 static PROJECT_ROOT: Lazy<String> =
     Lazy::new(|| std::env::var("BUCK_PROJECT_ROOT").expect("BUCK_PROJECT_ROOT must be set"));
@@ -39,8 +43,9 @@ pub async fn mount_fs(repo: &str, mr: &str) -> Result<bool, Box<dyn Error + Send
     let client = reqwest::Client::new();
     let mount_payload = json!({ "path": repo, "mr": mr });
 
+    let base = scorpio_base_url();
     let mount_res = client
-        .post("http://localhost:2725/api/fs/mount")
+        .post(format!("{base}/api/fs/mount"))
         .header("Content-Type", "application/json")
         .body(mount_payload.to_string())
         .send()
@@ -82,7 +87,7 @@ pub async fn mount_fs(repo: &str, mr: &str) -> Result<bool, Box<dyn Error + Send
         sleep(Duration::from_secs(poll_interval)).await;
         poll_interval = std::cmp::min(poll_interval * 2, max_poll_interval_secs);
 
-        let select_url = format!("http://localhost:2725/api/fs/select/{request_id}");
+        let select_url = format!("{}/api/fs/select/{request_id}", scorpio_base_url());
         let select_res = client.get(&select_url).send().await?;
         let select_body: Value = select_res.json().await?;
 
@@ -129,8 +134,9 @@ pub async fn unmount_fs() -> Result<String, Box<dyn Error + Send + Sync>> {
     let repo = (*MR_DIR).clone();
     let mount_payload = json!({ "path": repo });
 
+    let base = scorpio_base_url();
     let unmount_res = client
-        .post("http://localhost:2725/api/fs/umount")
+        .post(format!("{base}/api/fs/umount"))
         .header("Content-Type", "application/json")
         .body(mount_payload.to_string())
         .send()

--- a/orion/src/lib.rs
+++ b/orion/src/lib.rs
@@ -1,5 +1,6 @@
 mod api;
 mod buck_controller;
 pub mod repo;
+mod scorpio_api;
 mod util;
 pub mod ws;

--- a/orion/src/main.rs
+++ b/orion/src/main.rs
@@ -2,6 +2,7 @@
 mod api;
 mod buck_controller;
 pub mod repo;
+mod scorpio_api;
 mod util;
 mod ws;
 

--- a/orion/src/scorpio_api.rs
+++ b/orion/src/scorpio_api.rs
@@ -1,6 +1,10 @@
 pub fn base_url() -> String {
     let mut base = std::env::var("SCORPIO_API_BASE_URL")
         .unwrap_or_else(|_| "http://localhost:2725".to_string());
+
+    if !base.contains("://") {
+        base = format!("http://{base}");
+    }
     while base.ends_with('/') {
         base.pop();
     }

--- a/orion/src/scorpio_api.rs
+++ b/orion/src/scorpio_api.rs
@@ -1,0 +1,8 @@
+pub fn base_url() -> String {
+    let mut base = std::env::var("SCORPIO_API_BASE_URL")
+        .unwrap_or_else(|_| "http://localhost:2725".to_string());
+    while base.ends_with('/') {
+        base.pop();
+    }
+    base
+}

--- a/orion/td_util/Cargo.toml
+++ b/orion/td_util/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 argfile = "0.1.5"
-clap = {version = "4.1.4"}
+clap = { version = "4.1.4", features = ["derive"] }
 equivalent = "1.0.0"
 futures = "0.3.30"
 itertools = "0.14.0"

--- a/orion/td_util/src/no_hash.rs
+++ b/orion/td_util/src/no_hash.rs
@@ -29,9 +29,54 @@ impl Hasher for NoHash {
         panic!("Invalid use of NoHash")
     }
 
+    fn write_u8(&mut self, n: u8) {
+        self.write_u64(u64::from(n));
+    }
+
+    fn write_u16(&mut self, n: u16) {
+        self.write_u64(u64::from(n));
+    }
+
+    fn write_u32(&mut self, n: u32) {
+        self.write_u64(u64::from(n));
+    }
+
     fn write_u64(&mut self, n: u64) {
         // Check we haven't called it twice
         debug_assert_eq!(self.0, 0);
         self.0 = n;
+    }
+
+    fn write_u128(&mut self, n: u128) {
+        // Fold into u64 deterministically.
+        self.write_u64((n as u64) ^ ((n >> 64) as u64));
+    }
+
+    fn write_usize(&mut self, n: usize) {
+        self.write_u64(n as u64);
+    }
+
+    fn write_i8(&mut self, n: i8) {
+        self.write_u64(n as u64);
+    }
+
+    fn write_i16(&mut self, n: i16) {
+        self.write_u64(n as u64);
+    }
+
+    fn write_i32(&mut self, n: i32) {
+        self.write_u64(n as u64);
+    }
+
+    fn write_i64(&mut self, n: i64) {
+        self.write_u64(n as u64);
+    }
+
+    fn write_i128(&mut self, n: i128) {
+        self.write_u128(n as u128);
+    }
+
+    fn write_isize(&mut self, n: isize) {
+        self.write_u64(n as u64);
     }
 }


### PR DESCRIPTION
  提供一套 Linux 平台“标准开发镜像”，统一打包 Orion Worker / Scorpio（daemon）/ Buck2 及其系统依赖，支
  持 Linux 本地开发调试与 macOS/Windows 在远程 Linux 服务器上的统一联调环境，并补齐“挂载 + Buck2 构建 +
  日志查看”的使用手册。

  ## 实现内容

  ### Linux 标准镜像制作

  - 在 docker/dev-image/Dockerfile 中将 orion（Worker）、scorpio（FUSE daemon） 作为内置二进制编译并拷
   贝到运行时镜像；
  - 在镜像内下载并内置 buck2；
  - 实现“开箱即用，无需额外手动安装”。

  ### 版本与系统依赖固化

  - 通过 BUCK2_VERSION 固定 Buck2 版本；
  - 基础系统使用 Debian bookworm-slim；
  - FUSE/openssl 等运行依赖通过 apt 安装并写入镜像层（如 fuse3/libfuse3-3/libssl3）；
  - 镜像 LABEL 写入版本信息便于追踪。

  ### 配置能力

  - Scorpio：通过环境变量生成 scorpio.toml（envsubst），也支持挂载自定义配置文件；
  - Orion Worker：通过环境变量配置 SERVER_WS（外部 Orion Server WebSocket）、BUCK_PROJECT_ROOT/
    BUILD_TMP、SCORPIO_API_BASE_URL 等；
  - 后端端点（Mono / Orion Server）均通过环境变量注入，不在镜像内启动服务端。

  ### CI/CD 自动化
  - 新增 `.github/workflows/mega-dev-image-deploy.yml`：
    - 自动构建并推送 mega-dev 镜像到 Docker Registry
    - 支持多架构构建（linux/amd64, linux/arm64）
    - 通过 Git tag 或手动触发部署

  ### 使用场景支持

  - Linux：本地启动 Scorpio（FUSE mount）并在同容器内执行 Buck2，用于挂载测试、Buck2 构建排障；
  - macOS/Windows：在远程 Linux 服务器运行同一镜像，通过配置注入 Mono/Orion Server 地址，作为统一联调与
    测试环境使用。

  ### 开发/测试手册输出

  更新 docker/dev-image/README.md，包含：

  - 镜像说明与适用场景（client toolchain：scorpio + orion worker + buck2）；
  - Scorpio / Orion Worker 配置方式与依赖说明（Scorpio 挂载需要 Mono；FUSE 仅 Linux 可用）；
  - 常见流程示例：启动 Scorpio、创建 mount、在 Scorpio 容器内执行 buck2 build，并以终端输出作为构建日志；
  - 常见问题与排查建议（FUSE 权限、Mono 不可达、third-party 依赖等）。

Closed #1771 