### PR TITLE
feat: implement admin API and redis cache

### DIFF
--- a/ceres/Cargo.toml
+++ b/ceres/Cargo.toml
@@ -9,13 +9,13 @@ edition = "2024"
 name = "ceres"
 path = "src/lib.rs"
 
-
 [dependencies]
 common = { workspace = true }
 jupiter = { workspace = true }
 callisto = { workspace = true }
 git-internal = { workspace = true }
 bellatrix = { workspace = true }
+saturn = { workspace = true }
 
 anyhow = { workspace = true }
 # Use 0.16.0 version for GPG Verification
@@ -44,7 +44,6 @@ tokio-util = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 redis = { workspace = true }
 bincode = { workspace = true }
-
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/ceres/src/api_service/admin_ops.rs
+++ b/ceres/src/api_service/admin_ops.rs
@@ -1,0 +1,144 @@
+use redis::AsyncCommands;
+
+use crate::api_service::mono_api_service::MonoApiService;
+use common::errors::MegaError;
+use git_internal::internal::object::tree::Tree;
+use jupiter::utils::converter::FromMegaModel;
+
+// Admin permission constants
+pub const ADMIN_CACHE_TTL: u64 = 600;
+pub const ADMIN_DIR: &str = "/project";
+pub const ADMIN_DIR_NAME: &str = "project";
+pub const ADMIN_FILE: &str = ".mega_cedar.json";
+pub const ADMIN_CONFIG_PATH: &str = "project/.mega_cedar.json";
+
+impl MonoApiService {
+    /// Check if a user is an admin, with cache-first strategy.
+    pub async fn check_is_admin(&self, username: &str) -> Result<bool, MegaError> {
+        if let Ok(admins) = self.get_admins_from_cache().await {
+            return Ok(admins.contains(&username.to_string()));
+        }
+
+        let store = self.load_admin_entity_store().await?;
+        let resolver = saturn::admin_resolver::AdminResolver::from_entity_store(&store);
+        let admins = resolver.admin_list();
+
+        if let Err(e) = self.cache_admins(&admins).await {
+            tracing::warn!("Failed to write admin cache: {}", e);
+        }
+
+        Ok(resolver.is_admin(username))
+    }
+
+    /// Retrieve all admin usernames.
+    pub async fn get_all_admins(&self) -> Result<Vec<String>, MegaError> {
+        if let Ok(admins) = self.get_admins_from_cache().await {
+            return Ok(admins);
+        }
+
+        let store = self.load_admin_entity_store().await?;
+        let resolver = saturn::admin_resolver::AdminResolver::from_entity_store(&store);
+        let admins = resolver.admin_list();
+
+        if let Err(e) = self.cache_admins(&admins).await {
+            tracing::warn!("Failed to write admin cache: {}", e);
+        }
+
+        Ok(admins)
+    }
+
+    /// Delete admin list from Redis cache.
+    pub async fn invalidate_admin_cache(&self) {
+        let mut conn = self.git_object_cache.connection.clone();
+        let key = format!("{}:admin:list", self.git_object_cache.prefix);
+        if let Err(e) = conn.del::<_, ()>(&key).await {
+            tracing::warn!("Failed to invalidate admin cache: {}", e);
+        }
+    }
+
+    /// Load EntityStore from `/project/.mega_cedar.json`.
+    pub async fn load_admin_entity_store(
+        &self,
+    ) -> Result<saturn::entitystore::EntityStore, MegaError> {
+        let mono_storage = self.storage.mono_storage();
+
+        let project_tree = if let Ok(Some(project_ref)) = mono_storage.get_main_ref(ADMIN_DIR).await
+        {
+            Tree::from_mega_model(
+                mono_storage
+                    .get_tree_by_hash(&project_ref.ref_tree_hash)
+                    .await?
+                    .ok_or_else(|| {
+                        MegaError::Other(format!("Tree {} not found", project_ref.ref_tree_hash))
+                    })?,
+            )
+        } else {
+            let root_ref = mono_storage
+                .get_main_ref("/")
+                .await?
+                .ok_or_else(|| MegaError::Other("Root ref not found".into()))?;
+
+            let root_tree = Tree::from_mega_model(
+                mono_storage
+                    .get_tree_by_hash(&root_ref.ref_tree_hash)
+                    .await?
+                    .ok_or_else(|| MegaError::Other("Root tree not found".into()))?,
+            );
+
+            let project_item = root_tree
+                .tree_items
+                .iter()
+                .find(|item| item.name == ADMIN_DIR_NAME)
+                .ok_or_else(|| {
+                    MegaError::Other(format!("'{}' directory not found", ADMIN_DIR_NAME))
+                })?;
+
+            Tree::from_mega_model(
+                mono_storage
+                    .get_tree_by_hash(&project_item.id.to_string())
+                    .await?
+                    .ok_or_else(|| MegaError::Other("Project tree not found".into()))?,
+            )
+        };
+
+        let blob_item = project_tree
+            .tree_items
+            .iter()
+            .find(|item| item.name == ADMIN_FILE)
+            .ok_or_else(|| MegaError::Other(format!("{} not found", ADMIN_FILE)))?;
+
+        let content_bytes = self
+            .storage
+            .git_service
+            .get_object_as_bytes(&blob_item.id.to_string())
+            .await?;
+
+        let content = String::from_utf8(content_bytes)
+            .map_err(|e| MegaError::Other(format!("UTF-8 decode failed: {}", e)))?;
+
+        serde_json::from_str(&content)
+            .map_err(|e| MegaError::Other(format!("JSON parse failed: {}", e)))
+    }
+
+    async fn get_admins_from_cache(&self) -> Result<Vec<String>, MegaError> {
+        let mut conn = self.git_object_cache.connection.clone();
+        let key = format!("{}:admin:list", self.git_object_cache.prefix);
+        let data: Option<String> = conn.get(&key).await?;
+
+        match data {
+            Some(json) => serde_json::from_str(&json)
+                .map_err(|e| MegaError::Other(format!("Parse cache failed: {}", e))),
+            None => Err(MegaError::Other("Cache miss".into())),
+        }
+    }
+
+    async fn cache_admins(&self, admins: &[String]) -> Result<(), MegaError> {
+        let mut conn = self.git_object_cache.connection.clone();
+        let json = serde_json::to_string(admins)
+            .map_err(|e| MegaError::Other(format!("Serialize failed: {}", e)))?;
+
+        let key = format!("{}:admin:list", self.git_object_cache.prefix);
+        conn.set_ex::<_, _, ()>(&key, json, ADMIN_CACHE_TTL).await?;
+        Ok(())
+    }
+}

--- a/ceres/src/api_service/mod.rs
+++ b/ceres/src/api_service/mod.rs
@@ -31,6 +31,7 @@ use crate::{
     },
 };
 
+pub mod admin_ops;
 pub mod blame_ops;
 pub mod blob_ops;
 pub mod buck_tree_builder;

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -327,7 +327,7 @@ impl Default for DbConfig {
 pub struct MonoConfig {
     pub storage_type: StorageType,
     pub import_dir: PathBuf,
-    pub admin: String,
+    pub admin: Vec<String>,
     pub root_dirs: Vec<String>,
 }
 
@@ -336,7 +336,7 @@ impl Default for MonoConfig {
         Self {
             storage_type: StorageType::LocalFs,
             import_dir: PathBuf::from("/third-party"),
-            admin: String::from("admin"),
+            admin: vec!["admin".to_string()],
             root_dirs: vec![
                 "third-party".to_string(),
                 "project".to_string(),

--- a/config/config.toml
+++ b/config/config.toml
@@ -68,8 +68,9 @@ test_user_token = "mega"
 ## Mega treats files under this directory as import repo and other directories as monorepo
 import_dir = "/third-party"
 
-# Set System Admin in directory init, replace the admin's github username here
-admin = "admin"
+# Set System Admin(s) in directory init, these users will be added to the admin group
+# Supports multiple admins: admin = ["user1", "user2", "user3"]
+admin = ["benjamin.747"]
 
 # Set serveral root dirs in directory init
 root_dirs = ["third-party", "project", "doc", "release", "model"]

--- a/mono/src/api/api_router.rs
+++ b/mono/src/api/api_router.rs
@@ -17,8 +17,8 @@ use crate::api::{
     error::ApiError,
     notes::note_router,
     router::{
-        buck_router, cl_router, commit_router, conv_router, dynamic_sidebar_router, gpg_router,
-        issue_router, label_router, merge_queue_router, preview_router, repo_router,
+        admin_router, buck_router, cl_router, commit_router, conv_router, dynamic_sidebar_router,
+        gpg_router, issue_router, label_router, merge_queue_router, preview_router, repo_router,
         reviewer_router, tag_router, user_router,
     },
 };
@@ -44,6 +44,7 @@ pub fn routers() -> OpenApiRouter<MonoApiServiceState> {
         .merge(repo_router::routers())
         .merge(dynamic_sidebar_router::routers())
         .merge(buck_router::routers())
+        .merge(admin_router::routers())
 }
 
 /// Health Check

--- a/mono/src/api/router/admin_router.rs
+++ b/mono/src/api/router/admin_router.rs
@@ -1,0 +1,93 @@
+//! Admin-related API endpoints.
+//!
+//! Provides endpoints for admin permission checks:
+//! - `GET /api/v1/admin/me` - Check if current user is admin
+//! - `GET /api/v1/admin/list` - List all admins (admin-only)
+//!
+//! # Auth Behavior
+//! - 401 Unauthorized: No valid session (handled by `LoginUser` extractor)
+//! - 403 Forbidden: Logged in but not admin (for `/list` endpoint)
+
+use axum::{Json, extract::State};
+use serde::Serialize;
+use utoipa::ToSchema;
+use utoipa_axum::{router::OpenApiRouter, routes};
+
+use crate::api::MonoApiServiceState;
+use crate::api::error::ApiError;
+use crate::api::oauth::model::LoginUser;
+use crate::server::http_server::USER_TAG;
+use common::model::CommonResult;
+
+/// Response for `/api/v1/admin/me`.
+#[derive(Serialize, ToSchema)]
+pub struct IsAdminResponse {
+    pub is_admin: bool,
+}
+
+/// Response for `/api/v1/admin/list`.
+#[derive(Serialize, ToSchema)]
+pub struct AdminListResponse {
+    pub admins: Vec<String>,
+}
+
+/// Build the admin router.
+pub fn routers() -> OpenApiRouter<MonoApiServiceState> {
+    OpenApiRouter::new().nest(
+        "/admin",
+        OpenApiRouter::new()
+            .routes(routes!(is_admin_me))
+            .routes(routes!(admin_list)),
+    )
+}
+
+/// GET /api/v1/admin/me
+///
+/// Returns whether the current user is an admin based on Cedar entity data.
+#[utoipa::path(
+    get,
+    path = "/me",
+    responses(
+        (status = 200, body = CommonResult<IsAdminResponse>),
+        (status = 401, description = "Unauthorized"),
+    ),
+    tag = USER_TAG
+)]
+async fn is_admin_me(
+    user: LoginUser,
+    State(state): State<MonoApiServiceState>,
+) -> Result<Json<CommonResult<IsAdminResponse>>, ApiError> {
+    let is_admin = state.monorepo().check_is_admin(&user.username).await?;
+    Ok(Json(CommonResult::success(Some(IsAdminResponse {
+        is_admin,
+    }))))
+}
+
+/// GET /api/v1/admin/list
+///
+/// Returns a list of all admin usernames. Only admins can access this endpoint.
+#[utoipa::path(
+    get,
+    path = "/list",
+    responses(
+        (status = 200, body = CommonResult<AdminListResponse>),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden - not admin"),
+    ),
+    tag = USER_TAG
+)]
+async fn admin_list(
+    user: LoginUser,
+    State(state): State<MonoApiServiceState>,
+) -> Result<Json<CommonResult<AdminListResponse>>, ApiError> {
+    if !state.monorepo().check_is_admin(&user.username).await? {
+        return Err(ApiError::with_status(
+            http::StatusCode::FORBIDDEN,
+            anyhow::anyhow!("Admin access required"),
+        ));
+    }
+    let admins = state.monorepo().get_all_admins().await?;
+    Ok(Json(CommonResult::success(Some(AdminListResponse {
+        admins,
+    }))))
+}

--- a/mono/src/api/router/mod.rs
+++ b/mono/src/api/router/mod.rs
@@ -1,3 +1,4 @@
+pub mod admin_router;
 pub mod buck_router;
 pub mod cl_router;
 pub mod commit_router;

--- a/saturn/src/admin_resolver.rs
+++ b/saturn/src/admin_resolver.rs
@@ -1,0 +1,78 @@
+//! Admin resolution from Cedar entity store.
+//!
+//! This module provides utilities for determining admin status from Cedar entity data.
+//!
+//! # Assumptions
+//! - Only checks direct membership in `UserGroup::"admin"`
+//! - Admin is the most privileged group; no groups inherit from it
+//! - Path is fixed to `/project/.mega_cedar.json` (monorepo only)
+
+use std::collections::HashSet;
+
+use crate::entitystore::EntityStore;
+
+/// Resolver for admin permissions based on Cedar entity data.
+///
+/// Provides O(1) lookup for admin status after construction from [`EntityStore`].
+#[derive(Debug, Clone, Default)]
+pub struct AdminResolver {
+    admin_set: HashSet<String>,
+}
+
+impl AdminResolver {
+    /// Create from [`EntityStore`] by extracting users in the admin group.
+    ///
+    /// Uses [`EntityStore::extract_admin_usernames`] which checks direct
+    /// membership only (no BFS/DFS for group hierarchy).
+    pub fn from_entity_store(store: &EntityStore) -> Self {
+        let admin_set = store.extract_admin_usernames();
+        Self { admin_set }
+    }
+
+    /// Check if the given username is an admin.
+    ///
+    /// This is an O(1) lookup against the pre-computed admin set.
+    pub fn is_admin(&self, username: &str) -> bool {
+        self.admin_set.contains(username)
+    }
+
+    /// Get a list of all admin usernames.
+    ///
+    /// Returns pure usernames (e.g., `"alice"`), not Cedar EUIDs.
+    pub fn admin_list(&self) -> Vec<String> {
+        let mut admins: Vec<String> = self.admin_set.iter().cloned().collect();
+        admins.sort();
+        admins
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entitystore::generate_entity;
+
+    #[test]
+    fn test_admin_resolver_identifies_admin() {
+        let admins = vec!["alice".to_string()];
+        let entity_json = generate_entity(&admins, "/project").unwrap();
+        let store: EntityStore = serde_json::from_str(&entity_json).unwrap();
+
+        let resolver = AdminResolver::from_entity_store(&store);
+
+        assert!(resolver.is_admin("alice"), "alice should be admin");
+        assert!(!resolver.is_admin("bob"), "bob should not be admin");
+    }
+
+    #[test]
+    fn test_admin_list_returns_all_admins() {
+        let admins = vec!["genedna".to_string()];
+        let entity_json = generate_entity(&admins, "/project").unwrap();
+        let store: EntityStore = serde_json::from_str(&entity_json).unwrap();
+
+        let resolver = AdminResolver::from_entity_store(&store);
+        let admin_list = resolver.admin_list();
+
+        assert_eq!(admin_list.len(), 1);
+        assert!(admin_list.contains(&"genedna".to_string()));
+    }
+}

--- a/saturn/src/lib.rs
+++ b/saturn/src/lib.rs
@@ -1,5 +1,6 @@
 use std::fmt::{self, Display};
 
+pub mod admin_resolver;
 pub mod context;
 pub mod entitystore;
 mod objects;

--- a/saturn/src/objects.rs
+++ b/saturn/src/objects.rs
@@ -11,6 +11,18 @@ pub struct User {
     parents: HashSet<SaturnEUid>,
 }
 
+impl User {
+    /// Get the entity unique identifier.
+    pub fn euid(&self) -> &SaturnEUid {
+        &self.euid
+    }
+
+    /// Get the parent groups this user belongs to.
+    pub fn parents(&self) -> &HashSet<SaturnEUid> {
+        &self.parents
+    }
+}
+
 impl From<User> for Entity {
     fn from(value: User) -> Entity {
         Entity::new_no_attrs(


### PR DESCRIPTION
link #1755 


## Features
- **Multi-admin support**: `admin = ["user1", "user2"]` in config.toml
- **Redis caching**: 600s TTL with automatic invalidation on CL merge
- **API endpoints**: 
  - `GET /api/v1/admin/me` - Check if current user is admin
  - `GET /api/v1/admin/list` - Get all admins (admin-only)
## Flow
### 1. Initialization
- Read [admin](cci:1://file:///d:/Study/project/mega/ceres/src/api_service/admin_ops.rs:133:4-141:5) list from `config.toml`
- Generate `/project/.mega_cedar.json` with admin users in Cedar entity format
### 2. API Request Handling
- **Cache-first**: Check Redis cache (Key: `mega:admin:list`)
- **Lazy load**: On cache miss, load `.mega_cedar.json` from S3 and parse
- **Cache update**: Store parsed admin list in Redis (TTL 600s)
### 3. Dynamic Cache Invalidation
- **Monitor changes**: Detect modifications to `project/.mega_cedar.json` during CL merge
- **Auto-invalidate**: Clear Redis cache immediately on config changes
- **Immediate effect**: Next request triggers fresh load from S3
### 4. Access Control
- **Permission check**: `/admin/list` endpoint requires admin authentication
- **403 Forbidden**: Non-admin users receive access denied response