### PR TITLE
feat: add buckconfig and buckroot file

### DIFF
--- a/jupiter/src/utils/converter.rs
+++ b/jupiter/src/utils/converter.rs
@@ -471,17 +471,26 @@ fn inject_root_buck_files(
 
 fn generate_buckroot_content() -> String {
     // The .buckroot file is usually empty or contains a simple identifier.
-    "".to_string()
+    String::new()
 }
+
+/// Directories that should be excluded from Buck cell definitions.
+/// Currently only "doc" is excluded to preserve existing behavior.
+const EXCLUDED_BUCK_CELL_DIRS: &[&str] = &["doc"];
 
 fn generate_buckconfig_content(root_dirs: &[String]) -> String {
     let cells = root_dirs
         .iter()
-        .filter(|d| *d != "doc")
-        .map(|d| format!("  {d} = {d}\n"))
-        .collect::<String>();
+        .filter(|d| !EXCLUDED_BUCK_CELL_DIRS.contains(&d.as_str()))
+        .map(|d| format!("  {d} = {d}"))
+        .collect::<Vec<_>>()
+        .join("\n");
 
-    format!("[cells]\n{cells}")
+    if cells.is_empty() {
+        "[cells]\n".to_string()
+    } else {
+        format!("[cells]\n{cells}\n")
+    }
 }
 
 pub struct MegaModelConverter {

--- a/jupiter/src/utils/converter.rs
+++ b/jupiter/src/utils/converter.rs
@@ -786,7 +786,7 @@ mod test {
         let mega_blobs = converter.mega_blobs.borrow().clone();
         let dir_nums = mono_config.root_dirs.len();
         assert_eq!(mega_trees.len(), dir_nums + 1);
-        assert_eq!(mega_blobs.len(), dir_nums);
+        assert_eq!(mega_blobs.len(), dir_nums + 2); // 2 = .buckconfig + .buckroot
     }
 
     #[test]

--- a/jupiter/src/utils/converter.rs
+++ b/jupiter/src/utils/converter.rs
@@ -432,12 +432,56 @@ pub fn init_trees(
         blobs.push(blob);
     }
 
+    inject_root_buck_files(&mut root_items, &mut blobs, &mono_config.root_dirs);
+
     let root = Tree::from_tree_items(root_items).unwrap();
     (
         trees.into_iter().map(|x| (x.id, x)).collect(),
         blobs.into_iter().map(|x| (x.id, x)).collect(),
         root,
     )
+}
+
+/// Injects Buck configuration files (.buckroot and .buckconfig) into the root directory.
+fn inject_root_buck_files(
+    root_items: &mut Vec<TreeItem>,
+    blobs: &mut Vec<Blob>,
+    root_dirs: &[String],
+) {
+    // .buckroot
+    let buckroot_content = generate_buckroot_content();
+    let buckroot_blob = Blob::from_content(&buckroot_content);
+    root_items.push(TreeItem {
+        mode: TreeItemMode::Blob,
+        id: buckroot_blob.id,
+        name: String::from(".buckroot"),
+    });
+    blobs.push(buckroot_blob);
+
+    // .buckconfig
+    let buckconfig_content = generate_buckconfig_content(root_dirs);
+    let buckconfig_blob = Blob::from_content(&buckconfig_content);
+    root_items.push(TreeItem {
+        mode: TreeItemMode::Blob,
+        id: buckconfig_blob.id,
+        name: String::from(".buckconfig"),
+    });
+    blobs.push(buckconfig_blob);
+}
+
+fn generate_buckroot_content() -> String {
+    // The .buckroot file is usually empty or contains a simple identifier.
+    "".to_string()
+}
+
+fn generate_buckconfig_content(root_dirs: &[String]) -> String {
+    let cells = root_dirs
+        .iter()
+        .filter(|d| *d != "doc")
+        .map(|d| format!("  {d} = {d}\n"))
+        .collect::<String>();
+
+    format!("[cells]\n{cells}")
 }
 
 pub struct MegaModelConverter {


### PR DESCRIPTION
## Monorepo 初始化阶段自动生成 Buck 配置文件（.buckconfig / .buckroot）
issue：https://github.com/web3infra-foundation/mega/issues/1779

### 改动
1. 在 `init_trees` 函数中添加自动生成 Buck 配置文件的逻辑 `inject_root_buck_files`
2. 在根目录生成 `.buckroot` 内容为空，作为根目录的标识
3. 在根目录生成 `.buckconfig` ，内容类似于
```
[cells]
  project = project
  third-party = third-party
  model = model
  release = release
```
cell代表那些构建用到的目录，可以通过root_dir来生成，但是有些目录是不需要设置为cell的，比如 `doc`