### PR TITLE
fix(scorpio): stabilize Antares mounts, fix dicfuse parent.children, and add configurable HTTP bind address

### DIFF
--- a/docker/dev-image/.env.example
+++ b/docker/dev-image/.env.example
@@ -26,6 +26,10 @@ SCORPIO_LFS_URL=http://host.docker.internal:8000
 # Scorpio HTTP port
 SCORPIO_PORT=2725
 
+# Optional: override Scorpio bind address inside container (newer scorpio supports `--http-addr`)
+# If you set this, ensure your port mappings / SCORPIO_API_BASE_URL match.
+# SCORPIO_HTTP_ADDR=0.0.0.0:2725
+
 # Store path for Scorpio data (inside container)
 SCORPIO_STORE_PATH=/data/scorpio/store
 

--- a/orion-server/src/log/store/s3_log_store.rs
+++ b/orion-server/src/log/store/s3_log_store.rs
@@ -24,7 +24,7 @@ impl S3LogStore {
     ) -> Self {
         let region = Region::new(region_name.to_string());
 
-        let shared_config = aws_config::defaults(BehaviorVersion::v2025_08_07())
+        let shared_config = aws_config::defaults(BehaviorVersion::latest())
             .region(region.clone())
             .credentials_provider(Credentials::new(
                 access_key_id,


### PR DESCRIPTION
## Summary

This PR includes three key fixes and enhancements for Scorpio:

1. **Stabilize Antares mounts and cleanup on shutdown** - Ensures proper mount lifecycle management
2. **Fix dicfuse parent.children update in upsert_inode** - Corrects inode parent-child relationship tracking
3. **Add `--http-addr` CLI argument** - Allows configurable HTTP bind address for Scorpio daemon

## Changes

- Improved Antares mount stability and proper cleanup on shutdown
- Fixed parent.children synchronization in dicfuse upsert_inode operation
- Added CLI argument `--http-addr` for flexible HTTP server configuration