### PR TITLE
feat(orion): add --target-platforms to buck2 build command

### DIFF
--- a/orion/src/buck_controller.rs
+++ b/orion/src/buck_controller.rs
@@ -549,6 +549,8 @@ pub async fn build(
     let cmd = cmd
         .arg("build")
         .args(&targets)
+        .arg("--target-platforms")
+        .arg("prelude//platforms:default")
         .arg("--verbose=2")
         .current_dir(mount_point)
         .stdout(Stdio::piped())


### PR DESCRIPTION
新增了buck2 构建参数`--target-platforms`，适应现在的toolchains