### PR TITLE
fix: s3_compatible upload fail

### DIFF
--- a/io-orbit/src/factory.rs
+++ b/io-orbit/src/factory.rs
@@ -84,6 +84,7 @@ async fn build_s3_compatible(
         .with_access_key_id(&s3_cfg.access_key_id)
         .with_secret_access_key(&s3_cfg.secret_access_key)
         .with_endpoint(&s3_cfg.endpoint_url)
+        .with_allow_http(true)
         .with_virtual_hosted_style_request(false)
         .build()
         .map_err(|e| MegaError::Other(e.to_string()))?;


### PR DESCRIPTION
The failure is caused by a combination of default AmazonS3Builder behaviors in object_store:

1.HTTP endpoints are disallowed by default

-    object_store requires explicit opt-in for non-HTTPS endpoints.
-  RustFS exposes its S3-compatible API over HTTP by default, which requires S3 clients (such as object_store) to explicitly opt in to non-HTTPS endpoints via allow_http.


linked #1821