### PR TITLE
[orion]ADD: generic API payloads and WS messages model

### DIFF
--- a/api-model/src/buck2/api.rs
+++ b/api-model/src/buck2/api.rs
@@ -1,0 +1,40 @@
+//! Buck2 build API models.
+//!
+//! This module defines the request/response types used between
+//! Orion-Server and Monorepo during a build.
+//!
+//! ## Design notes
+//! - Types here are **pure data models**
+//! - No Buck2 execution logic should live in this module
+//! - Used by both server and mono crates only
+
+use serde::{Deserialize, Serialize};
+
+use crate::buck2::types::{ProjectRelativePath, Status};
+
+/// Parameters required to build a task.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct TaskBuildRequest {
+    /// The repository base path
+    pub repo: String,
+    /// The change list link (URL)
+    pub cl: String,
+    /// The list of file diff changes
+    pub changes: Vec<Status<ProjectRelativePath>>,
+}
+
+/// Result of a task build operation containing status and metadata. Used by Orion-Server
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TaskBuildResult {
+    /// Whether the build operation was successful
+    pub success: bool,
+    /// Unique identifier for the build task
+    pub id: String,
+    /// Process exit code (None if not yet completed)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    /// Human-readable status or error message
+    pub message: String,
+}

--- a/api-model/src/buck2/mod.rs
+++ b/api-model/src/buck2/mod.rs
@@ -1,0 +1,3 @@
+pub mod api;
+pub mod types;
+pub mod ws;

--- a/api-model/src/buck2/types.rs
+++ b/api-model/src/buck2/types.rs
@@ -1,0 +1,41 @@
+//! Types related to Buck2 build system.
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// Request from server to worker to build a target.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+pub enum Status<Path> {
+    Modified(Path),
+    Added(Path),
+    Removed(Path),
+}
+
+/// Task phase when in buck2 build
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+pub enum TaskPhase {
+    DownloadingSource,
+    RunningBuild,
+}
+
+/// Represents a file path relative to the project root.
+#[allow(dead_code)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Deserialize, Serialize)]
+pub struct ProjectRelativePath(String);
+
+impl ProjectRelativePath {
+    /// Creates a new ProjectRelativePath from a string slice.
+    pub fn new(path: &str) -> Self {
+        Self(path.to_owned())
+    }
+
+    /// Attempts to create a ProjectRelativePath from an absolute path and a base path.
+    pub fn from_abs(abs_path: &str, base: &str) -> Option<Self> {
+        let opt = abs_path
+            .strip_prefix(base)
+            .map(|s| s.trim_start_matches("/"));
+        opt.map(|s| Self(s.to_owned()))
+    }
+}

--- a/api-model/src/buck2/ws.rs
+++ b/api-model/src/buck2/ws.rs
@@ -1,7 +1,8 @@
 //! Websocket message protocol for communication between orion worker and server.
 
-use crate::buck2::types::{ProjectRelativePath, Status, TaskPhase};
 use serde::{Deserialize, Serialize};
+
+use crate::buck2::types::{ProjectRelativePath, Status, TaskPhase};
 
 /// Message protocol for WebSocket communication between worker and server.
 #[allow(dead_code)]

--- a/api-model/src/buck2/ws.rs
+++ b/api-model/src/buck2/ws.rs
@@ -1,0 +1,57 @@
+//! Websocket message protocol for communication between orion worker and server.
+
+use crate::buck2::types::{ProjectRelativePath, Status, TaskPhase};
+use serde::{Deserialize, Serialize};
+
+/// Message protocol for WebSocket communication between worker and server.
+#[allow(dead_code)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "type")]
+pub enum WSMessage {
+    // Server -> Worker messages
+    Task {
+        id: String,
+        repo: String,
+        cl_link: String,
+        changes: Vec<Status<ProjectRelativePath>>,
+    },
+
+    TaskWithTargets {
+        id: String,
+        repo: String,
+        cl_link: String,
+        // targets: Vec<Target>,
+    },
+
+    // Worker -> Server messages
+    Register {
+        id: String,
+        hostname: String,
+        orion_version: String,
+    },
+
+    Heartbeat,
+    // Sent when a task is in the build process and its execution phase changes.
+    TaskPhaseUpdate {
+        id: String,
+        phase: TaskPhase,
+    },
+
+    TaskAck {
+        id: String,
+        success: bool,
+        message: String,
+    },
+
+    TaskBuildOutput {
+        id: String,
+        output: String,
+    },
+
+    TaskBuildComplete {
+        id: String,
+        success: bool,
+        exit_code: Option<i32>,
+        message: String,
+    },
+}

--- a/api-model/src/lib.rs
+++ b/api-model/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod buck2;
 pub mod git;


### PR DESCRIPTION
This PR creates a new crate in `api-models`, extracting all the replicating API models and WS Messages into one single module for `buck2` related workflow.

The new api-model will be used as a backbone for any future refactoring between `mono - orion_server - orion`