### PR TITLE
refactor: unify Orion log models in api-model

### DIFF
--- a/api-model/src/lib.rs
+++ b/api-model/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod buck2;
 pub mod common;
 pub mod git;
+pub mod orion;

--- a/api-model/src/orion/log.rs
+++ b/api-model/src/orion/log.rs
@@ -1,0 +1,77 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// Supported read modes for log APIs.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum LogReadMode {
+    Full,
+    Segment,
+}
+
+impl Default for LogReadMode {
+    fn default() -> Self {
+        Self::Full
+    }
+}
+
+/// Log stream event emitted by Orion worker/build processing.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct LogEvent {
+    pub task_id: String,
+    pub repo_name: String,
+    pub build_id: String,
+    pub line: String,
+    pub is_end: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct LogSegment {
+    pub build_id: String,
+    pub offset: u64,
+    pub len: usize,
+    pub data: String,
+    pub next_offset: u64,
+    pub file_size: u64,
+    pub eof: bool,
+}
+
+/// Query parameters for target log APIs.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct TargetLogQuery {
+    #[serde(default)]
+    pub r#type: LogReadMode,
+    pub offset: Option<usize>,
+    pub limit: Option<usize>,
+}
+
+/// Query parameters for task history log APIs.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct TaskHistoryQuery {
+    pub task_id: String,
+    pub build_id: String,
+    pub repo: String,
+    pub start: Option<usize>,
+    pub end: Option<usize>,
+}
+
+/// Log lines response for history reads.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct LogLinesResponse {
+    pub data: Vec<String>,
+    pub len: usize,
+}
+
+/// Log lines response for target reads.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct TargetLogLinesResponse {
+    pub data: Vec<String>,
+    pub len: usize,
+    pub build_id: String,
+}
+
+/// Error response for log-related APIs.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct LogErrorResponse {
+    pub message: String,
+}

--- a/api-model/src/orion/log.rs
+++ b/api-model/src/orion/log.rs
@@ -2,17 +2,12 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 /// Supported read modes for log APIs.
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum LogReadMode {
+    #[default]
     Full,
     Segment,
-}
-
-impl Default for LogReadMode {
-    fn default() -> Self {
-        Self::Full
-    }
 }
 
 /// Log stream event emitted by Orion worker/build processing.

--- a/api-model/src/orion/mod.rs
+++ b/api-model/src/orion/mod.rs
@@ -1,0 +1,1 @@
+pub mod log;

--- a/orion-server/Cargo.toml
+++ b/orion-server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 orion = { workspace = true }
 common = { workspace = true}
 io-orbit = { workspace = true }
+api-model = { workspace = true }
 
 http = { workspace = true }
 axum = { workspace = true, features = ["macros", "ws"] }

--- a/orion-server/src/api.rs
+++ b/orion-server/src/api.rs
@@ -4,6 +4,10 @@ use std::{
 };
 
 use anyhow::Result;
+use api_model::orion::log::{
+    LogErrorResponse, LogEvent, LogLinesResponse, LogReadMode, TargetLogLinesResponse,
+    TargetLogQuery, TaskHistoryQuery,
+};
 use axum::{
     Json, Router,
     extract::{
@@ -31,10 +35,6 @@ use tokio_stream::wrappers::IntervalStream;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use api_model::orion::log::{
-    LogErrorResponse, LogEvent, LogLinesResponse, LogReadMode, TargetLogLinesResponse,
-    TargetLogQuery, TaskHistoryQuery,
-};
 use crate::{
     auto_retry::AutoRetryJudger,
     log::log_service::LogService,

--- a/orion-server/src/log/log_service.rs
+++ b/orion-server/src/log/log_service.rs
@@ -1,9 +1,9 @@
 use std::{path::Path, sync::Arc};
 
+use api_model::orion::log::LogEvent;
 use futures::{Stream, StreamExt};
 use tokio_stream::wrappers::BroadcastStream;
 
-use api_model::orion::log::LogEvent;
 use crate::log::store::LogStore;
 
 #[derive(Clone)]

--- a/orion-server/src/log/log_service.rs
+++ b/orion-server/src/log/log_service.rs
@@ -3,16 +3,8 @@ use std::{path::Path, sync::Arc};
 use futures::{Stream, StreamExt};
 use tokio_stream::wrappers::BroadcastStream;
 
+use api_model::orion::log::LogEvent;
 use crate::log::store::LogStore;
-
-#[derive(Clone, Debug)]
-pub struct LogEvent {
-    pub task_id: String,
-    pub repo_name: String,
-    pub build_id: String,
-    pub line: String,
-    pub is_end: bool,
-}
 
 #[derive(Clone)]
 pub struct LogService {

--- a/orion-server/src/scheduler.rs
+++ b/orion-server/src/scheduler.rs
@@ -218,25 +218,6 @@ pub struct TaskScheduler {
     pub conn: DatabaseConnection,
 }
 
-/// Log segment read result
-#[derive(Debug, Clone, Serialize, ToSchema)]
-pub struct LogSegment {
-    /// build id / log file name
-    pub build_id: String,
-    /// Requested starting offset
-    pub offset: u64,
-    /// Bytes actually read
-    pub len: usize,
-    /// UTF-8 (lossy) decoded data slice
-    pub data: String,
-    /// Next offset (offset + len)
-    pub next_offset: u64,
-    /// Total file size in bytes
-    pub file_size: u64,
-    /// Whether we reached end of file
-    pub eof: bool,
-}
-
 /// Errors when reading a log segment
 #[allow(dead_code)]
 #[derive(Debug)]

--- a/orion-server/src/server.rs
+++ b/orion-server/src/server.rs
@@ -44,11 +44,16 @@ use crate::{
     components(
         schemas(
             crate::scheduler::BuildRequest,
-            crate::scheduler::LogSegment,
+            api_model::orion::log::LogSegment,
+            api_model::orion::log::LogLinesResponse,
+            api_model::orion::log::TargetLogLinesResponse,
+            api_model::orion::log::LogErrorResponse,
             api::TaskStatusEnum,
             api::BuildDTO,
             api::TargetDTO,
-            api::TargetLogQuery,
+            api_model::orion::log::TargetLogQuery,
+            api_model::orion::log::LogReadMode,
+            api_model::orion::log::TaskHistoryQuery,
             api::TaskInfoDTO,
             api::OrionClientInfo,
             api::OrionClientStatus,


### PR DESCRIPTION
- Move shared Orion log request/response models into api-model
- Reuse unified log models in orion-server to standardize API boundaries
- Align log API schemas and responses with shared models