### PR TITLE
fix(orion): skip incompatible targets for buck2 builds

### DIFF
--- a/orion/buck/run.rs
+++ b/orion/buck/run.rs
@@ -200,6 +200,8 @@ pub fn targets_arguments() -> &'static [&'static str] {
     &[
         "targets",
         "//...",
+        "--target-platforms",
+        "prelude//platforms:default",
         "--streaming",
         "--keep-going",
         "--no-cache",

--- a/orion/src/buck_controller.rs
+++ b/orion/src/buck_controller.rs
@@ -689,6 +689,9 @@ pub async fn build(
             .args(&targets)
             .arg("--target-platforms")
             .arg("prelude//platforms:default")
+            // Avoid failing the whole build when a target is explicitly incompatible
+            // with the selected platform (e.g., macOS-only crates on Linux builders).
+            .arg("--skip-incompatible-targets")
             .arg("--verbose=2")
             .current_dir(mount_point)
             .stdout(Stdio::piped())


### PR DESCRIPTION
## 概要
  - 在 buck2 targets 发现阶段加入 `--target-platforms prelude//platforms:default`，提前过滤不兼容目标。
  - 在 buck2 build 阶段加入 `--skip-incompatible-targets`，避免 macOS-only crate 在 Linux 上直接失败。

  ## 问题
  Linux 构建时，目标发现包含 macOS-only crate（例如 system-configuration），构建阶段尝试编译导致失败。
  ## 备注
  - 应在 third-party 的 BUCK 中补 `target_compatible_with`（macOS-only crates）。
