### PR TITLE
[scorpio]:fix issue #1534 where a temporary mount point was incorrect…

### DIFF
--- a/scorpio/src/server/mod.rs
+++ b/scorpio/src/server/mod.rs
@@ -72,7 +72,24 @@ pub async fn mount_filesystem<F: Filesystem + std::marker::Sync + Send + 'static
     //let logfs = LoggingFileSystem::new(fs);
 
     let mount_path: OsString = OsString::from(mountpoint);
-
+    let path = std::path::Path::new(&mount_path);
+    if !path.exists() {
+        if let Err(e) = std::fs::create_dir_all(path) {
+            panic!("failed to create mountpoint: {}", e);
+        }
+    }
+    if !path.exists() {
+        panic!("mountpoint does not exist");
+    }
+    if !path.is_dir() {
+        panic!("mountpoint is not a directory");
+    }
+    let has_entries = std::fs::read_dir(path)
+        .map(|mut it| it.next().is_some())
+        .unwrap_or(true);
+    if has_entries {
+        panic!("mountpoint is not empty or is inaccessible");
+    }
     let uid = unsafe { libc::getuid() };
     let gid = unsafe { libc::getgid() };
 

--- a/scorpio/tests/mount_lookup_test.rs
+++ b/scorpio/tests/mount_lookup_test.rs
@@ -1,0 +1,57 @@
+use scorpio::dicfuse::store::{DictionaryStore, PathLookupStatus};
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn lookup_status_found_normal_path() {
+    let tmp = tempdir().unwrap();
+    let store = DictionaryStore::new_with_store_path(tmp.path().to_str().unwrap()).await;
+
+    store.insert_mock_item(1, 0, "", true).await;
+    store.insert_mock_item(2, 1, "repo", true).await;
+    store.insert_mock_item(3, 2, "a", true).await;
+
+    let status = store.lookup_path_status("/repo/a").await.unwrap();
+    assert_eq!(status, PathLookupStatus::Found(3));
+}
+
+#[tokio::test]
+async fn lookup_status_temp_mount_add_temp_point() {
+    let tmp = tempdir().unwrap();
+    let store = DictionaryStore::new_with_store_path(tmp.path().to_str().unwrap()).await;
+
+    store.insert_mock_item(1, 0, "", true).await;
+    store.insert_mock_item(2, 1, "repo", true).await;
+
+    let inode = store.add_temp_point("repo/tmp").await.unwrap();
+    let status = store.lookup_path_status("/repo/tmp").await.unwrap();
+    assert_eq!(status, PathLookupStatus::Found(inode));
+}
+
+#[tokio::test]
+async fn lookup_status_not_found_normal_mount() {
+    let tmp = tempdir().unwrap();
+    let store = DictionaryStore::new_with_store_path(tmp.path().to_str().unwrap()).await;
+
+    store.insert_mock_item(1, 0, "", true).await;
+    store.insert_mock_item(2, 1, "repo", true).await;
+
+    // Parent directory exists but has never been loaded; dicfuse must not claim NotFound.
+    let status = store.lookup_path_status("/repo/missing").await.unwrap();
+    assert_eq!(
+        status,
+        PathLookupStatus::ParentNotLoaded {
+            parent_path: "/repo".to_string()
+        }
+    );
+}
+
+#[tokio::test]
+async fn lookup_status_not_found_without_ancestor() {
+    let tmp = tempdir().unwrap();
+    let store = DictionaryStore::new_with_store_path(tmp.path().to_str().unwrap()).await;
+
+    store.insert_mock_item(1, 0, "", true).await;
+
+    let status = store.lookup_path_status("/missing").await.unwrap();
+    assert_eq!(status, PathLookupStatus::NotFound);
+}


### PR DESCRIPTION
[scorpio]:fix issue #1534 where a temporary mount point was incorrectly created when the normal mount at the dicfuse path was not loaded or did not exist.