### PR TITLE
fix(CL router): cl path dismatch

### DIFF
--- a/mono/src/api/router/cl_router.rs
+++ b/mono/src/api/router/cl_router.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use api_model::common::{CommonPage, CommonResult, PageParams};
 use axum::{
     Json,
@@ -323,12 +321,10 @@ async fn cl_files_list(
     let new_files = stg.get_commit_blobs(&cl.to_hash).await?;
     let cl_diff_files = stg.cl_files_list(old_files, new_files.clone()).await?; // TODO
 
-    let cl_base = PathBuf::from(cl.path);
     let res = cl_diff_files
         .into_iter()
         .map(|m| {
-            let mut item: ClFilesRes = m.into();
-            item.path = cl_base.join(item.path).to_string_lossy().to_string();
+            let item: ClFilesRes = m.into();
             item
         })
         .collect::<Vec<ClFilesRes>>();


### PR DESCRIPTION
### 问题
code review 进行评论的时候需要获取到 commit sha。目前前端能从接口获取到的是长路径，但是cl目录树这里是短路径
路径匹配不太友好 。

### 解决方案
`cl_files_list` router 返回短路径。目前这个接口没有被使用，不用担心代码改动影响其他逻辑
```rs
/// Get Change List file list
#[utoipa::path(
    get,
    params(
        ("link", description = "CL link"),
    ),
    path = "/{link}/files-list",
    responses(
        (status = 200, body = CommonResult<Vec<ClFilesRes>>, content_type = "application/json")
    ),
    tag = CL_TAG
)]
async fn cl_files_list(
    Path(link): Path<String>,
    state: State<MonoApiServiceState>,
) -> Result<Json<CommonResult<Vec<ClFilesRes>>>, ApiError> {
    let cl = state
        .cl_stg()
        .get_cl(&link)
        .await?
        .ok_or(MegaError::Other("CL Not Found".to_string()))?;

    let stg = state.monorepo();
    let old_files = stg.get_commit_blobs(&cl.from_hash).await?;
    let new_files = stg.get_commit_blobs(&cl.to_hash).await?;
    let cl_diff_files = stg.cl_files_list(old_files, new_files.clone()).await?; // TODO

    let res = cl_diff_files
        .into_iter()
        .map(|m| {
            let item: ClFilesRes = m.into();
            item
        })
        .collect::<Vec<ClFilesRes>>();
    Ok(Json(CommonResult::success(Some(res))))
}
```
