### PR TITLE
Refactor: DynamicSidebar default initialization to use config.toml

### DIFF
--- a/common/src/config/mod.rs
+++ b/common/src/config/mod.rs
@@ -98,6 +98,8 @@ pub struct Config {
     pub object_storage: ObjectStorageConfig,
     #[serde(default)]
     pub orion_server: Option<OrionServerConfig>,
+    #[serde(default)]
+    pub sidebar: SidebarConfig,
 }
 
 impl Config {
@@ -136,6 +138,7 @@ impl Config {
             buck: None,
             object_storage: ObjectStorageConfig::default(),
             orion_server: None,
+            sidebar: SidebarConfig::default(),
         }
     }
 
@@ -873,6 +876,55 @@ impl Default for BuckConfig {
             completed_retention_days: default_completed_retention_days(),
         }
     }
+}
+
+#[derive(Deserialize, Debug)]
+pub struct SidebarConfig {
+    pub default_items: Vec<SidebarItem>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct SidebarItem {
+    pub public_id: String,
+    pub label: String,
+    pub href: String,
+    #[serde(default = "default_visible")]
+    pub visible: bool,
+    pub order_index: i32,
+}
+
+impl Default for SidebarConfig {
+    fn default() -> Self {
+        Self {
+            default_items: vec![
+                SidebarItem {
+                    public_id: "home".to_string(),
+                    label: "Home".to_string(),
+                    href: "/posts".to_string(),
+                    visible: true,
+                    order_index: 0,
+                },
+                SidebarItem {
+                    public_id: "inbox".to_string(),
+                    label: "Inbox".to_string(),
+                    href: "/inbox".to_string(),
+                    visible: true,
+                    order_index: 1,
+                },
+                SidebarItem {
+                    public_id: "docs".to_string(),
+                    label: "Docs".to_string(),
+                    href: "/notes".to_string(),
+                    visible: true,
+                    order_index: 2,
+                },
+            ],
+        }
+    }
+}
+
+fn default_visible() -> bool {
+    true
 }
 
 #[cfg(test)]

--- a/config/config-test.toml
+++ b/config/config-test.toml
@@ -249,3 +249,24 @@ db_url = "postgres://postgres:postgres@localhost/orion"
 
 # Mono server base URL for file/blob API
 monobase_url = "http://localhost:8000"
+
+# Default sidebar menu items.
+# - Visible = false means the menu is hidden by default.
+# - Order_index controls the display order in the UI.
+# - Changes here do not affect old environments; only new or empty DBs will use these defaults.
+[sidebar]
+default_items = [
+    { public_id = "home", label = "Home", href = "/posts", visible = true, order_index = 0 },
+    { public_id = "inbox", label = "Inbox", href = "/inbox", visible = true, order_index = 1 },
+    { public_id = "chat", label = "Chat", href = "/chat", visible = true, order_index = 2 },
+    { public_id = "notes", label = "Docs", href = "/notes", visible = true, order_index = 3 },
+    { public_id = "calls", label = "Calls", href = "/calls", visible = false, order_index = 4 },
+    { public_id = "drafts", label = "Drafts", href = "/drafts", visible = true, order_index = 5 },
+    { public_id = "code", label = "Code", href = "/code", visible = true, order_index = 6 },
+    { public_id = "tags", label = "Tags", href = "/code/tags", visible = true, order_index = 7 },
+    { public_id = "cl", label = "Change List", href = "/cl", visible = true, order_index = 8 },
+    { public_id = "mq", label = "Merge Queue", href = "/queue/main", visible = true, order_index = 9 },
+    { public_id = "issue", label = "Issue", href = "/issue", visible = true, order_index = 10 },
+    { public_id = "rust", label = "Rust", href = "/rust", visible = false, order_index = 11 },
+    { public_id = "oc", label = "Orion Client", href = "/oc", visible = true, order_index = 13 },
+]

--- a/config/config-workflow.toml
+++ b/config/config-workflow.toml
@@ -163,3 +163,24 @@ db_url = "postgres://postgres:postgres@localhost/orion"
 
 # Mono server base URL for file/blob API
 monobase_url = "http://localhost:8000"
+
+# Default sidebar menu items.
+# - Visible = false means the menu is hidden by default.
+# - Order_index controls the display order in the UI.
+# - Changes here do not affect old environments; only new or empty DBs will use these defaults.
+[sidebar]
+default_items = [
+    { public_id = "home", label = "Home", href = "/posts", visible = true, order_index = 0 },
+    { public_id = "inbox", label = "Inbox", href = "/inbox", visible = true, order_index = 1 },
+    { public_id = "chat", label = "Chat", href = "/chat", visible = true, order_index = 2 },
+    { public_id = "notes", label = "Docs", href = "/notes", visible = true, order_index = 3 },
+    { public_id = "calls", label = "Calls", href = "/calls", visible = false, order_index = 4 },
+    { public_id = "drafts", label = "Drafts", href = "/drafts", visible = true, order_index = 5 },
+    { public_id = "code", label = "Code", href = "/code", visible = true, order_index = 6 },
+    { public_id = "tags", label = "Tags", href = "/code/tags", visible = true, order_index = 7 },
+    { public_id = "cl", label = "Change List", href = "/cl", visible = true, order_index = 8 },
+    { public_id = "mq", label = "Merge Queue", href = "/queue/main", visible = true, order_index = 9 },
+    { public_id = "issue", label = "Issue", href = "/issue", visible = true, order_index = 10 },
+    { public_id = "rust", label = "Rust", href = "/rust", visible = false, order_index = 11 },
+    { public_id = "oc", label = "Orion Client", href = "/oc", visible = true, order_index = 13 },
+]

--- a/config/config.toml
+++ b/config/config.toml
@@ -253,3 +253,24 @@ db_url = "postgres://postgres:postgres@localhost/orion"
 
 # Mono server base URL for file/blob API (file blob endpoint)
 monobase_url = "http://git.gitmega.com"
+
+# Default sidebar menu items.
+# - Visible = false means the menu is hidden by default.
+# - Order_index controls the display order in the UI.
+# - Changes here do not affect old environments; only new or empty DBs will use these defaults.
+[sidebar]
+default_items = [
+    { public_id = "home", label = "Home", href = "/posts", visible = true, order_index = 0 },
+    { public_id = "inbox", label = "Inbox", href = "/inbox", visible = true, order_index = 1 },
+    { public_id = "chat", label = "Chat", href = "/chat", visible = true, order_index = 2 },
+    { public_id = "notes", label = "Docs", href = "/notes", visible = true, order_index = 3 },
+    { public_id = "calls", label = "Calls", href = "/calls", visible = false, order_index = 4 },
+    { public_id = "drafts", label = "Drafts", href = "/drafts", visible = true, order_index = 5 },
+    { public_id = "code", label = "Code", href = "/code", visible = true, order_index = 6 },
+    { public_id = "tags", label = "Tags", href = "/code/tags", visible = true, order_index = 7 },
+    { public_id = "cl", label = "Change List", href = "/cl", visible = true, order_index = 8 },
+    { public_id = "mq", label = "Merge Queue", href = "/queue/main", visible = true, order_index = 9 },
+    { public_id = "issue", label = "Issue", href = "/issue", visible = true, order_index = 10 },
+    { public_id = "rust", label = "Rust", href = "/rust", visible = false, order_index = 11 },
+    { public_id = "oc", label = "Orion Client", href = "/oc", visible = true, order_index = 13 },
+]

--- a/jupiter/src/migration/m20260209_064016_remove_default_dynamic_sidebar.rs
+++ b/jupiter/src/migration/m20260209_064016_remove_default_dynamic_sidebar.rs
@@ -1,0 +1,51 @@
+//! Migration to Clean Up Historical Default Data in `dynamic_sidebar` Table
+//!
+//! This migration exists solely to address a historical technical debt in
+//! `jupiter/src/migration/m20251203_013745_add_dynamic_sidebar.rs`.
+//! In that original migration, default menu items were hard-coded and inserted
+//! into the `dynamic_sidebar` table. This approach mixes schema definition
+//! with data initialization, which is no longer the desired practice.
+//!
+//! Key principles applied in this migration:
+//!
+//! 1. **Schema vs. Data Separation**
+//!    - Migrations should only define or modify database **schema** (tables, columns, indexes).
+//!    - They should **not** insert default or seed data.  
+//!    - Default menu data is now managed at **runtime** via a bootstrap method (`DynamicSidebarStorage::bootstrap_sidebar`) that reads from configuration (e.g., `sidebar.default.toml`).
+//!
+//! 2. **Purpose of This Migration**
+//!    - Remove historical default data inserted by the old migration.
+//!    - Keep the table structure and indexes intact, so the table is empty but ready for runtime seeding.
+//!    - This ensures **new environments** or **fresh deployments** do not carry legacy hard-coded menu items.
+//!
+//! 3. **Future Default Menu Management**
+//!    - Default menu items are now fully configurable and maintained via `sidebar.default.toml` or application config.
+//!    - `DynamicSidebarStorage::bootstrap_sidebar` is responsible for checking if the table is empty and inserting defaults at runtime.
+//!    - This approach provides flexibility, maintains backward compatibility, and separates schema migrations from dynamic, configurable data.
+
+use sea_orm::DatabaseBackend;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let backend = manager.get_database_backend();
+
+        match backend {
+            DatabaseBackend::Postgres => {
+                let sql = r#"DELETE FROM dynamic_sidebar;"#;
+                manager.get_connection().execute_unprepared(sql).await?;
+            }
+            DatabaseBackend::Sqlite | DatabaseBackend::MySql => {}
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _: &SchemaManager) -> Result<(), DbErr> {
+        Ok(())
+    }
+}

--- a/jupiter/src/migration/mod.rs
+++ b/jupiter/src/migration/mod.rs
@@ -82,6 +82,7 @@ mod m20260127_081517_create_build_triggers;
 mod m20260128_080549_add_mega_code_review_anchor_and_position;
 mod m20260130_065535_refactor_orion_module;
 mod m20260208_012349_change_build_events;
+mod m20260209_064016_remove_default_dynamic_sidebar;
 
 /// Creates a primary key column definition with big integer type.
 ///
@@ -154,6 +155,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260128_080549_add_mega_code_review_anchor_and_position::Migration),
             Box::new(m20260130_065535_refactor_orion_module::Migration),
             Box::new(m20260208_012349_change_build_events::Migration),
+            Box::new(m20260209_064016_remove_default_dynamic_sidebar::Migration),
         ]
     }
 }

--- a/jupiter/src/storage/mod.rs
+++ b/jupiter/src/storage/mod.rs
@@ -151,7 +151,12 @@ impl Storage {
         let reviewer_storage = ClReviewerStorage { base: base.clone() };
         let merge_queue_storage = MergeQueueStorage::new(base.clone());
         let buck_storage = BuckStorage { base: base.clone() };
+
         let dynamic_sidebar_storage = DynamicSidebarStorage { base: base.clone() };
+        dynamic_sidebar_storage
+            .init_default_sidebars(&config.sidebar)
+            .await?;
+
         let code_review_comment_storage = CodeReviewCommentStorage { base: base.clone() };
         let code_review_thread_storage = CodeReviewThreadStorage { base: base.clone() };
         let build_trigger_storage = BuildTriggerStorage { base: base.clone() };


### PR DESCRIPTION
### 背景 / 历史问题

* 历史 migration `m20251203_013745_add_dynamic_sidebar.rs` 中插入了硬编码的默认菜单数据。
```rs
async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
        // ......

        let backend = manager.get_database_backend();

        match backend {
            DatabaseBackend::Postgres => {
                let sql = r#"
                    INSERT INTO dynamic_sidebar (public_id, label, href, visible, order_index) VALUES
                    ('home', 'Home', '/posts', true, 0),
                    ('inbox', 'Inbox', '/inbox', true, 1),
                    ('chat', 'Chat', '/chat', true, 2),
                    ('notes', 'Docs', '/notes', true, 3),
                    ('calls', 'Calls', '/calls', true, 4),
                    ('drafts', 'Drafts', '/drafts', true, 5),
                    ('code', 'Code', '/code', true, 6),
                    ('tags', 'Tags', '/code/tags', true, 7),
                    ('cl', 'Change List', '/cl', true, 8),
                    ('mq', 'Merge Queue', '/queue/main', true, 9),
                    ('issue', 'Issue', '/issue', true, 10),
                    ('rust', 'Rust', '/rust', true, 11);
                "#;

                manager.get_connection().execute_unprepared(sql).await?;
            }
            DatabaseBackend::Sqlite | DatabaseBackend::MySql => {}
        }

        Ok(())
    }
```
* 这样导致：

  * 新环境无法灵活修改默认菜单；
  * 表始终非空，无法通过表为空来判断新环境；
  * 默认菜单逻辑散落在 migration，维护成本高。
* 我们希望遵循基本的约定：

  1. **Migration 只做 表 结构明确的数据升级**；
  2. **默认菜单的声明只存在于 config**；
  3. **init 逻辑只在运行时检查表为空时执行**。

### 设计思路

* **移除历史 migration 的默认数据插入**：

  * 保留表结构创建；
  * 针对历史负债，可以单独写 migration 清空表（让表变为空）。
* **动态初始化默认菜单**：

  * 在 `DynamicSidebarStorage` 中增加 `init_default_sidebars` 方法；
  * 方法从 `config/config.toml` 读取 `sidebar.default_items`；
```toml
# Default sidebar menu items.
# - Visible = false means the menu is hidden by default.
# - Order_index controls the display order in the UI.
# - Changes here do not affect old environments; only new or empty DBs will use these defaults.
[sidebar]
default_items = [
    { public_id = "home", label = "Home", href = "/posts", visible = true, order_index = 0 },
    { public_id = "inbox", label = "Inbox", href = "/inbox", visible = true, order_index = 1 },
    { public_id = "chat", label = "Chat", href = "/chat", visible = true, order_index = 2 },
    { public_id = "notes", label = "Docs", href = "/notes", visible = true, order_index = 3 },
    { public_id = "calls", label = "Calls", href = "/calls", visible = false, order_index = 4 },
    { public_id = "drafts", label = "Drafts", href = "/drafts", visible = true, order_index = 5 },
    { public_id = "code", label = "Code", href = "/code", visible = true, order_index = 6 },
    { public_id = "tags", label = "Tags", href = "/code/tags", visible = true, order_index = 7 },
    { public_id = "cl", label = "Change List", href = "/cl", visible = true, order_index = 8 },
    { public_id = "mq", label = "Merge Queue", href = "/queue/main", visible = true, order_index = 9 },
    { public_id = "issue", label = "Issue", href = "/issue", visible = true, order_index = 10 },
    { public_id = "rust", label = "Rust", href = "/rust", visible = false, order_index = 11 },
    { public_id = "oc", label = "Orion Client", href = "/oc", visible = true, order_index = 13 },
]

```
  * 如果表为空，插入默认菜单，保证幂等性；
  * Storage 初始化阶段调用该方法，确保新环境启动时自动 bootstrap。
* **默认菜单更新**：

  * 现在默认菜单配置集中在 `config/config.toml`，修改时只需要改配置，不再改 migration。

### 默认 sidebar 改动

* 隐藏了历史 migration 中的 `Calls` 和 `Rust` 默认项，即字段`visible = false`；
* 新增 `Orion Client`（public_id=`oc`）；