### PR TITLE
fix: BUCK upload API hash verification using raw content SHA-1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ smallvec = "1.15.1"
 bytes = "1.11.1"
 chrono = { version = "0.4.43", features = ["serde"] }
 hex = "0.4.3"
+sha1 = "0.10"
 sha2 = "0.10.9"
 
 idgenerator = "2.0.0"

--- a/ceres/Cargo.toml
+++ b/ceres/Cargo.toml
@@ -44,6 +44,8 @@ tokio-util = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 redis = { workspace = true }
 bincode = { workspace = true }
+sha1 = { workspace = true }
+hex = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/ceres/src/api_service/blob_ops.rs
+++ b/ceres/src/api_service/blob_ops.rs
@@ -11,6 +11,8 @@ use git_internal::{
     hash::ObjectHash,
     internal::object::{blob::Blob, tree::TreeItemMode},
 };
+use hex;
+use sha1::{Digest, Sha1};
 
 use crate::{
     api_service::{ApiHandler, tree_ops},
@@ -179,4 +181,237 @@ pub async fn get_blob_as_string<T: ApiHandler + ?Sized>(
         }
     }
     Ok(None)
+}
+
+/// Extract raw content slice from Git blob data with strict validation and fallback
+///
+/// Git blob format: "blob <size>\0<content>"
+/// This function attempts to parse Git blob format, but falls back to returning
+/// raw content if validation fails. This ensures data is never lost.
+///
+/// # Validation Rules
+/// 1. Must start with "blob "
+/// 2. Must contain a null byte separator
+/// 3. Size field must be valid ASCII digits
+/// 4. Size must match actual content length
+///
+/// # Returns
+/// Content slice (Git blob header stripped if valid, or original data if fallback).
+/// This function never fails - it always returns a valid slice, either by stripping
+/// the Git blob header or by returning the original data unchanged.
+fn extract_raw_content_from_blob(blob_data: &[u8]) -> &[u8] {
+    // If it doesn't start with "blob ", return as-is
+    if !blob_data.starts_with(b"blob ") {
+        return blob_data;
+    }
+
+    // Try to parse as Git blob format: "blob <size>\0<content>"
+    if let Some(null_pos) = blob_data.iter().position(|&b| b == 0) {
+        let size_bytes = &blob_data[5..null_pos];
+
+        // Check if size field contains only ASCII digits
+        if !size_bytes.iter().all(|&b| b.is_ascii_digit()) {
+            return blob_data;
+        }
+
+        // Parse size as usize
+        if let Ok(size_str) = std::str::from_utf8(size_bytes) {
+            if let Ok(expected_size) = size_str.parse::<usize>() {
+                // Validate: size must match actual content length
+                let actual_size = blob_data.len() - (null_pos + 1);
+                if expected_size == actual_size {
+                    // Perfect match, return stripped content
+                    return &blob_data[null_pos + 1..];
+                }
+            }
+        }
+
+        // Validation failed, fallback to original content
+        tracing::warn!(
+            "Blob data starts with 'blob ' but validation failed, treating as raw content. \
+             This may indicate data corruption or API contract violation."
+        );
+    }
+    // No null byte found, fallback to original content
+
+    // Not Git format, or validation failed, return original content
+    blob_data
+}
+
+/// Get content hashes (raw SHA-1) for multiple file paths in batch
+///
+/// This function retrieves blob IDs for files, extracts raw content from Git blobs,
+/// and calculates SHA-1 hash of the raw content.
+///
+/// # Arguments
+/// * `handler` - API handler implementing ApiHandler trait
+/// * `paths` - Slice of file paths to query
+/// * `refs` - Optional commit hash or ref name
+///
+/// # Returns
+/// HashMap mapping file paths to raw content SHA-1 hashes
+/// Files not found will not be in the result
+pub async fn get_files_content_hashes<T: ApiHandler + ?Sized>(
+    handler: &T,
+    paths: &[PathBuf],
+    refs: Option<&str>,
+) -> Result<HashMap<PathBuf, String>, GitError> {
+    if paths.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    // Get blob IDs for all files
+    let blob_ids = get_files_blob_ids(handler, paths, refs).await?;
+
+    if blob_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    // Pre-allocate HashMap capacity to avoid reallocation during insertion
+    let capacity = blob_ids.len();
+    let mut result = HashMap::with_capacity(capacity);
+
+    // Batch read blob contents
+    let max_concurrent = handler.get_context().get_recommended_batch_concurrency();
+    let mut blob_stream = stream::iter(blob_ids.into_iter())
+        .map(|(path, blob_hash)| {
+            // Use into_iter to get ownership, no clone needed
+            let blob_hash_str = blob_hash.to_string();
+            async move {
+                // Get blob data
+                let result = handler.get_raw_blob_by_hash(&blob_hash_str).await;
+
+                // If successful, immediately calculate hash
+                match result {
+                    Ok(blob_data) => {
+                        // Extract raw content from Git blob format (returns slice, no copy)
+                        let content_slice = extract_raw_content_from_blob(&blob_data);
+
+                        // Calculate SHA-1 hash of raw content
+                        let mut hasher = Sha1::new();
+                        hasher.update(content_slice);
+                        let hash = hex::encode(hasher.finalize());
+                        (path, Ok(hash))
+                    }
+                    Err(e) => (path, Err((blob_hash_str, e))),
+                }
+            }
+        })
+        .buffer_unordered(max_concurrent);
+
+    // Process each result as it completes
+    while let Some((path, result_item)) = blob_stream.next().await {
+        match result_item {
+            Ok(content_hash) => {
+                result.insert(path, content_hash);
+            }
+            Err((hash, e)) => {
+                tracing::warn!("Failed to read blob {} for path {:?}: {}", hash, path, e);
+                // Skip this file
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_raw_content_from_blob_valid_git_format() {
+        // Test valid Git blob format
+        let blob_data = b"blob 5\0hello";
+        let result = extract_raw_content_from_blob(blob_data);
+        assert_eq!(result, b"hello");
+        // Verify it's a slice reference, not a copy
+        assert_eq!(result.as_ptr(), unsafe { blob_data.as_ptr().add(7) });
+    }
+
+    #[test]
+    fn test_extract_raw_content_from_blob_raw_content() {
+        // Test raw content (not Git format)
+        let raw_data = b"hello world";
+        let result = extract_raw_content_from_blob(raw_data);
+        assert_eq!(result, raw_data);
+        assert_eq!(result.as_ptr(), raw_data.as_ptr());
+    }
+
+    #[test]
+    fn test_extract_raw_content_from_blob_size_mismatch() {
+        // Test size mismatch (should fallback to original content)
+        let invalid_blob = b"blob 10\0hello"; // size says 10, but content is 5 bytes
+        let result = extract_raw_content_from_blob(invalid_blob);
+        assert_eq!(result, invalid_blob); // Should return original content due to fallback
+    }
+
+    #[test]
+    fn test_extract_raw_content_from_blob_non_digit_size() {
+        // Test non-digit size (should fallback to original content)
+        let invalid_size = b"blob abc\0hello";
+        let result = extract_raw_content_from_blob(invalid_size);
+        assert_eq!(result, invalid_size); // Should return original content due to fallback
+    }
+
+    #[test]
+    fn test_extract_raw_content_from_blob_file_starting_with_blob() {
+        // Test file starting with "blob " but not Git format (should return as-is)
+        let regular_file = b"blob is a git object type";
+        let result = extract_raw_content_from_blob(regular_file);
+        assert_eq!(result, regular_file);
+    }
+
+    #[test]
+    fn test_extract_raw_content_from_blob_empty_blob() {
+        // Test empty blob
+        let empty_blob = b"blob 0\0";
+        let result = extract_raw_content_from_blob(empty_blob);
+        assert_eq!(result, b"");
+    }
+
+    #[test]
+    fn test_extract_raw_content_from_blob_large_blob() {
+        // Test large blob
+        let large_content = vec![b'a'; 1000];
+        let mut large_blob = format!("blob {}\0", large_content.len()).into_bytes();
+        large_blob.extend_from_slice(&large_content);
+        let result = extract_raw_content_from_blob(&large_blob);
+        assert_eq!(result, &large_content);
+    }
+
+    #[test]
+    fn test_extract_raw_content_from_blob_missing_null() {
+        // Test missing null byte (should fallback to original content)
+        let no_null = b"blob 5hello";
+        let result = extract_raw_content_from_blob(no_null);
+        assert_eq!(result, no_null); // Should return original content due to fallback
+    }
+
+    #[test]
+    fn test_extract_raw_content_from_blob_empty_size() {
+        // Test empty size field (should fallback to original content)
+        let empty_size = b"blob \0hello";
+        let result = extract_raw_content_from_blob(empty_size);
+        assert_eq!(result, empty_size); // Should return original content due to fallback
+    }
+
+    #[test]
+    fn test_extract_raw_content_from_blob_fallback_behavior() {
+        // Test fallback behavior: format validation fails should return original content
+        // Size mismatch case
+        let invalid_blob = b"blob 10\0hello"; // size says 10, but content is 5 bytes
+        let result = extract_raw_content_from_blob(invalid_blob);
+        assert_eq!(result, invalid_blob); // Should return original content
+
+        // No null byte case
+        let no_null = b"blob 5hello"; // no null byte
+        let result = extract_raw_content_from_blob(no_null);
+        assert_eq!(result, no_null); // Should return original content
+
+        // Non-digit size case
+        let invalid_size = b"blob abc\0hello";
+        let result = extract_raw_content_from_blob(invalid_size);
+        assert_eq!(result, invalid_size); // Should return original content
+    }
 }

--- a/ceres/src/api_service/mono_api_service.rs
+++ b/ceres/src/api_service/mono_api_service.rs
@@ -2536,7 +2536,8 @@ impl MonoApiService {
             .map(|f| PathBuf::from(&f.path))
             .collect();
 
-        let existing_file_hashes = crate::api_service::blob_ops::get_files_blob_ids(
+        // Get content hashes (raw SHA-1) for comparison with client-provided hashes
+        let existing_file_hashes = crate::api_service::blob_ops::get_files_content_hashes(
             self,
             &manifest_paths,
             session.from_hash.as_deref(),
@@ -2544,9 +2545,20 @@ impl MonoApiService {
         .await
         .map_err(MegaError::Git)?;
 
-        let existing_file_hashes: HashMap<PathBuf, String> = existing_file_hashes
+        // Get Git blob IDs for storing in database
+        // blob_id field stores Git blob hash, not content hash
+        let existing_blob_ids_map = crate::api_service::blob_ops::get_files_blob_ids(
+            self,
+            &manifest_paths,
+            session.from_hash.as_deref(),
+        )
+        .await
+        .map_err(MegaError::Git)?;
+
+        // Convert ObjectHash to String for storage
+        let existing_blob_ids: HashMap<PathBuf, String> = existing_blob_ids_map
             .into_iter()
-            .map(|(path, sha1)| (path, sha1.to_string()))
+            .map(|(path, blob_hash)| (path, blob_hash.to_string()))
             .collect();
 
         // Convert payload to service layer type
@@ -2566,7 +2578,13 @@ impl MonoApiService {
         let svc_resp = self
             .storage
             .buck_service
-            .process_manifest(username, cl_link, service_payload, existing_file_hashes)
+            .process_manifest(
+                username,
+                cl_link,
+                service_payload,
+                existing_file_hashes,
+                existing_blob_ids,
+            )
             .await?;
 
         // Convert back to API layer response

--- a/ceres/src/api_service/mono_api_service.rs
+++ b/ceres/src/api_service/mono_api_service.rs
@@ -2536,24 +2536,15 @@ impl MonoApiService {
             .map(|f| PathBuf::from(&f.path))
             .collect();
 
-        // Get content hashes (raw SHA-1) for comparison with client-provided hashes
-        let existing_file_hashes = crate::api_service::blob_ops::get_files_content_hashes(
-            self,
-            &manifest_paths,
-            session.from_hash.as_deref(),
-        )
-        .await
-        .map_err(MegaError::Git)?;
-
-        // Get Git blob IDs for storing in database
-        // blob_id field stores Git blob hash, not content hash
-        let existing_blob_ids_map = crate::api_service::blob_ops::get_files_blob_ids(
-            self,
-            &manifest_paths,
-            session.from_hash.as_deref(),
-        )
-        .await
-        .map_err(MegaError::Git)?;
+        // Get content hashes (raw SHA-1) and blob IDs
+        let (existing_file_hashes, existing_blob_ids_map) =
+            crate::api_service::blob_ops::get_files_content_hashes_with_blob_ids(
+                self,
+                &manifest_paths,
+                session.from_hash.as_deref(),
+            )
+            .await
+            .map_err(MegaError::Git)?;
 
         // Convert ObjectHash to String for storage
         let existing_blob_ids: HashMap<PathBuf, String> = existing_blob_ids_map

--- a/jupiter/Cargo.toml
+++ b/jupiter/Cargo.toml
@@ -46,6 +46,7 @@ redis = { workspace = true, features = [
     "connection-manager",
 ] }
 rustls = { workspace = true }
+sha1 = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
 

--- a/jupiter/src/migration/m20260211_102158_add_username_to_mega_cl_sqlite.rs
+++ b/jupiter/src/migration/m20260211_102158_add_username_to_mega_cl_sqlite.rs
@@ -1,0 +1,49 @@
+use sea_orm::DatabaseBackend;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let backend = manager.get_database_backend();
+
+        match backend {
+            DatabaseBackend::Sqlite => {
+                // Add username column to mega_cl table for SQLite
+                // This migration fixes the issue where m20250812_022434_alter_mega_mr
+                // skipped adding username column for SQLite, and the table was later
+                // renamed from mega_mr to mega_cl in m20250930_024736_mr_to_cl
+                manager
+                    .alter_table(
+                        Table::alter()
+                            .table(MegaCl::Table)
+                            .add_column_if_not_exists(
+                                ColumnDef::new(Alias::new("username"))
+                                    .string()
+                                    .not_null()
+                                    .default(""),
+                            )
+                            .to_owned(),
+                    )
+                    .await?;
+            }
+            DatabaseBackend::Postgres | DatabaseBackend::MySql => {
+                // Already handled by m20250812_022434_alter_mega_mr
+                // No action needed
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum MegaCl {
+    Table,
+}

--- a/jupiter/src/migration/mod.rs
+++ b/jupiter/src/migration/mod.rs
@@ -84,6 +84,7 @@ mod m20260130_065535_refactor_orion_module;
 mod m20260208_012349_change_build_events;
 mod m20260209_064016_remove_default_dynamic_sidebar;
 mod m20260210_062050_create_target_state_history;
+mod m20260211_102158_add_username_to_mega_cl_sqlite;
 
 /// Creates a primary key column definition with big integer type.
 ///
@@ -158,6 +159,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260208_012349_change_build_events::Migration),
             Box::new(m20260209_064016_remove_default_dynamic_sidebar::Migration),
             Box::new(m20260210_062050_create_target_state_history::Migration),
+            Box::new(m20260211_102158_add_username_to_mega_cl_sqlite::Migration),
         ]
     }
 }

--- a/mono/Cargo.toml
+++ b/mono/Cargo.toml
@@ -84,3 +84,5 @@ mimalloc = { workspace = true }
 tempfile = { workspace = true }
 serial_test = { workspace = true }
 qlean = {workspace = true}
+hex = { workspace = true }
+sha1 = { workspace = true }

--- a/mono/tests/buck_service_tests.rs
+++ b/mono/tests/buck_service_tests.rs
@@ -9,7 +9,6 @@ use bytes::Bytes;
 use chrono::{Duration, Utc};
 use common::config::BuckConfig;
 use git_internal::internal::object::blob::Blob;
-use hex;
 use jupiter::{
     service::{
         buck_service::{BuckService, ManifestPayload},
@@ -587,7 +586,7 @@ async fn test_process_manifest_with_existing_files() {
     );
     existing_file_hashes.insert(
         PathBuf::from("file3.txt"),
-        "old_hash_old_hash_old_hash_old_hash_oldx".to_string(), // 40 chars for SHA-1
+        "dddddddddddddddddddddddddddddddddddddddd".to_string(), // Valid hex hash (40 lowercase hex chars)
     );
 
     // Mock blob IDs for unchanged file (file2.txt)


### PR DESCRIPTION
Fix the hash verification logic in BUCK upload API to use raw content SHA-1 hash instead of Git blob hash. Git computes blob hash over a wrapped representation ("blob <size>\0<content>"), which doesn't match the raw content hash that clients provide.

Fixes #1922 

Changes:
- Fix hash verification in upload_file() to compute and verify raw content SHA-1
- Add get_files_content_hashes() to extract raw content from Git blobs
- Implement fallback strategy: return original content if blob format validation fails
- Update tests to use raw content hash for verification

Files modified:
- jupiter/src/service/buck_service.rs: Fix hash verification logic
- ceres/src/api_service/blob_ops.rs: Add content hash extraction with optimizations
- ceres/src/api_service/mono_api_service.rs: Update to use new hash extraction
- mono/tests/buck_service_tests.rs: Update tests for new hash logic
- jupiter/src/migration/m20260211_102158_add_username_to_mega_cl_sqlite.rs: Add migration
- Cargo.toml files: Add sha1 and hex dependencies

Fixes: Hash mismatch error when uploading files with correct content