### PR TITLE
fix: extend PR branch setup to all PR event types in claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -63,13 +63,26 @@ jobs:
           )
 
     steps:
+      # Checkout PR Branch (for comments)
+      - name: Resolve PR Ref
+        id: resolve-pr-ref
+        if: github.event_name == 'issue_comment' && github.event.issue.pull_request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=${{ github.event.issue.number }}
+          echo "Resolving HEAD SHA for PR #$PR_NUMBER..."
+          PR_SHA=$(gh pr view $PR_NUMBER --repo ${{ github.repository }} --json headRefOid -q .headRefOid)
+          echo "Resolved SHA: $PR_SHA"
+          echo "pr_sha=$PR_SHA" >> $GITHUB_OUTPUT
+
       # Checkout the repository at the appropriate commit for review
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           # Use PR head SHA for pull_request_target to review the actual PR code
           # For comment events, this will default to the base branch (PR context is inferred by Claude action)
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ steps.resolve-pr-ref.outputs.pr_sha || github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
 
       # Invoke Claude to perform an automated PR review with progress tracking

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -86,19 +86,31 @@ jobs:
           fetch-depth: 20
 
       # Manually setup PR branch to workaround Claude Action issue with forks
-      # We create the branch from the current HEAD (which is the secure, verified SHA checked out above)
-      # This avoids fetching mutable refs from the network, addressing the "Untrusted Checkout" vulnerability
+      # For issue_comment events, the action does not attempt to fetch the PR branch,
+      # so we create it locally from the current HEAD (secure, verified SHA)
       - name: Setup PR Branch
-        if: |
-          (github.event_name == 'issue_comment' && github.event.issue.pull_request) ||
-          github.event_name == 'pull_request_target' ||
-          github.event_name == 'pull_request_review_comment' ||
-          github.event_name == 'pull_request_review'
+        if: github.event_name == 'issue_comment' && github.event.issue.pull_request
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
           echo "Setting up local PR branch pr-$PR_NUMBER..."
           git checkout -b pr-$PR_NUMBER
+
+      # Fix git protocol for PR ref access
+      # actions/checkout@v6 creates a shallow clone with only refs/heads/* in the fetch
+      # refspec. The claude-code-action internally runs:
+      #   git fetch origin pull/N/head:pr-N
+      # Under git protocol v2 (default since git 2.26), the client sends ref-prefix
+      # filters to the server. Since refs/pull/* is not in the configured fetch refspec,
+      # the server may not return refs/pull/N/head, causing "couldn't find remote ref".
+      # Adding refs/pull/*/head to the fetch refspec ensures these refs are discoverable.
+      - name: Configure git for PR ref access
+        if: |
+          github.event_name == 'pull_request_target' ||
+          github.event_name == 'pull_request_review_comment' ||
+          github.event_name == 'pull_request_review'
+        run: |
+          git config --add remote.origin.fetch '+refs/pull/*/head:refs/remotes/origin/pull/*/head'
 
       # Invoke Claude to perform an automated PR review with progress tracking
       - name: Run Claude Code Review

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -83,10 +83,21 @@ jobs:
           # Use PR head SHA for pull_request_target to review the actual PR code
           # For comment events, this will default to the base branch (PR context is inferred by Claude action)
           ref: ${{ steps.resolve-pr-ref.outputs.pr_sha || github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 1
+          fetch-depth: 20
+
+      # Manually setup PR branch to workaround Claude Action issue with forks
+      - name: Setup PR Branch
+        if: github.event_name == 'issue_comment' && github.event.issue.pull_request
+        env:
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          echo "Setting up local PR branch pr-$PR_NUMBER..."
+          git fetch origin refs/pull/$PR_NUMBER/head:pr-$PR_NUMBER
+          git checkout pr-$PR_NUMBER
 
       # Invoke Claude to perform an automated PR review with progress tracking
-      - name: PR Review with Progress Tracking
+      - name: Run Claude Code Review
+        id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -65,69 +65,12 @@ jobs:
     steps:
       # Checkout the repository at the appropriate commit for review
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          # Use PR head SHA for pull_request_target, fallback to current SHA otherwise
-          fetch-depth: 0
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
-
-      # Handle fork branches for pull_request_target events
-      - name: Setup Fork Remote (for pull_request_target)
-        if: ${{ github.event_name == 'pull_request_target' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          PR_HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
-          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.name }}
-          REPO_OWNER: ${{ github.repository_owner }}
-        run: |
-          PR_NUMBER="$PR_NUMBER"
-          HEAD_REF="$PR_HEAD_REF"
-          HEAD_OWNER="$PR_HEAD_OWNER"
-          HEAD_REPO="$PR_HEAD_REPO"
-          CURRENT_OWNER="$REPO_OWNER"
-
-          # For forked PRs, temporarily change origin URL to fork repository
-          # This allows claude-code-action to fetch the PR branch correctly
-          if [ "$HEAD_OWNER" != "$CURRENT_OWNER" ]; then
-            echo "PR is from fork: $HEAD_OWNER/$HEAD_REPO"
-            FORK_URL="https://github.com/$HEAD_OWNER/$HEAD_REPO.git"
-            echo "Temporarily changing origin URL to fork: $FORK_URL"
-            git remote set-url origin "$FORK_URL"
-            git fetch origin "$HEAD_REF"
-            git branch "$HEAD_REF" "origin/$HEAD_REF" 2>/dev/null || git branch -f "$HEAD_REF" "origin/$HEAD_REF"
-          fi
-
-      # For comment-driven triggers, ensure we have the correct PR branch checked out
-      - name: Checkout PR Branch (for comments)
-        if: ${{ github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_NUMBER=${{ github.event.issue.number || github.event.pull_request.number }}
-
-          # Fetch PR metadata: head branch name and source repository
-          PR_DATA=$(gh pr view $PR_NUMBER --json headRefName,headRepositoryOwner,headRepository,baseRefName)
-          HEAD_REF=$(echo "$PR_DATA" | jq -r '.headRefName')
-          HEAD_OWNER=$(echo "$PR_DATA" | jq -r '.headRepositoryOwner.login')
-          HEAD_REPO=$(echo "$PR_DATA" | jq -r '.headRepository.name')
-          BASE_BRANCH=$(echo "$PR_DATA" | jq -r '.baseRefName')
-          CURRENT_OWNER="${{ github.repository_owner }}"
-
-          # For forked PRs, temporarily change origin URL to fork repository
-          # This allows claude-code-action to fetch the PR branch correctly
-          if [ "$HEAD_OWNER" != "$CURRENT_OWNER" ]; then
-            echo "PR is from fork: $HEAD_OWNER/$HEAD_REPO"
-            FORK_URL="https://github.com/$HEAD_OWNER/$HEAD_REPO.git"
-            echo "Temporarily changing origin URL to fork: $FORK_URL"
-            git remote set-url origin "$FORK_URL"
-          fi
-
-          # Fetch and checkout the PR branch
-          git fetch origin "$HEAD_REF"
-          git branch "$HEAD_REF" "origin/$HEAD_REF" 2>/dev/null || git branch -f "$HEAD_REF" "origin/$HEAD_REF"
-          git checkout "$HEAD_REF"
+          # Use PR head SHA for pull_request_target to review the actual PR code
+          # For comment events, this will default to the base branch (PR context is inferred by Claude action)
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 1
 
       # Invoke Claude to perform an automated PR review with progress tracking
       - name: PR Review with Progress Tracking
@@ -176,4 +119,3 @@ jobs:
           # Restrict tools that Claude can use during the review
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
-

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -86,14 +86,15 @@ jobs:
           fetch-depth: 20
 
       # Manually setup PR branch to workaround Claude Action issue with forks
+      # We create the branch from the current HEAD (which is the secure, verified SHA checked out above)
+      # This avoids fetching mutable refs from the network, addressing the "Untrusted Checkout" vulnerability
       - name: Setup PR Branch
         if: github.event_name == 'issue_comment' && github.event.issue.pull_request
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |
           echo "Setting up local PR branch pr-$PR_NUMBER..."
-          git fetch origin refs/pull/$PR_NUMBER/head:pr-$PR_NUMBER
-          git checkout pr-$PR_NUMBER
+          git checkout -b pr-$PR_NUMBER
 
       # Invoke Claude to perform an automated PR review with progress tracking
       - name: Run Claude Code Review

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -89,9 +89,13 @@ jobs:
       # We create the branch from the current HEAD (which is the secure, verified SHA checked out above)
       # This avoids fetching mutable refs from the network, addressing the "Untrusted Checkout" vulnerability
       - name: Setup PR Branch
-        if: github.event_name == 'issue_comment' && github.event.issue.pull_request
+        if: |
+          (github.event_name == 'issue_comment' && github.event.issue.pull_request) ||
+          github.event_name == 'pull_request_target' ||
+          github.event_name == 'pull_request_review_comment' ||
+          github.event_name == 'pull_request_review'
         env:
-          PR_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
           echo "Setting up local PR branch pr-$PR_NUMBER..."
           git checkout -b pr-$PR_NUMBER


### PR DESCRIPTION
The Setup PR Branch workaround only ran for issue_comment events,
causing claude-code-action to fail with "couldn't find remote ref
pull/N/head" on pull_request_target and other PR events. Could you extend the
condition to cover all PR-related event types?

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Quanyi Ma <eli@patch.sh>