### PR TITLE
fix(buck): remove redundant commit_message from Complete API

### DIFF
--- a/ceres/src/api_service/mono_api_service.rs
+++ b/ceres/src/api_service/mono_api_service.rs
@@ -2614,7 +2614,7 @@ impl MonoApiService {
         &self,
         username: &str,
         cl_link: &str,
-        payload: CompletePayload,
+        _payload: CompletePayload,
     ) -> Result<CompleteResponse, MegaError> {
         let session = self
             .storage
@@ -2681,10 +2681,10 @@ impl MonoApiService {
             })
             .collect();
 
-        let commit_message = payload
+        // Use commit_message from session
+        let commit_message = session
             .commit_message
             .clone()
-            .or(session.commit_message.clone())
             .unwrap_or_else(|| "Upload via buck push".to_string());
 
         let commit_result = if file_changes.is_empty() {
@@ -2721,14 +2721,7 @@ impl MonoApiService {
         let svc_resp: SvcCompleteResponse = self
             .storage
             .buck_service
-            .complete_upload(
-                username,
-                cl_link,
-                SvcCompletePayload {
-                    commit_message: payload.commit_message.clone(),
-                },
-                artifacts,
-            )
+            .complete_upload(username, cl_link, SvcCompletePayload {}, artifacts)
             .await?;
 
         // Calculate uploaded files count

--- a/ceres/src/model/buck.rs
+++ b/ceres/src/model/buck.rs
@@ -144,11 +144,10 @@ pub struct FileUploadResponse {
 }
 
 /// Request payload for completing upload
+///
+/// Empty payload - commit_message is set exclusively in Manifest phase
 #[derive(Debug, Deserialize, ToSchema)]
-pub struct CompletePayload {
-    /// Optional commit message (overrides manifest message)
-    pub commit_message: Option<String>,
-}
+pub struct CompletePayload {}
 
 /// Response for upload completion
 ///


### PR DESCRIPTION
Remove redundant `commit_message` from the BUCK Upload Complete API. Manifest is the only place that accepts and stores `commit_message`; Complete now reads it from the session instead of the request body.

Fixes #1926 

Changes

- Complete API: Remove `commit_message` from `CompletePayload`; use `session.commit_message` as the source.
- BuckService: Read `commit_message` from session; do not overwrite it when updating session status.
- Tests: Updated to set `commit_message` in the session and use an empty `CompletePayload` for Complete.

Breaking Change

`commit_message` in the Complete request body is ignored. Clients should send it only in Manifest requests.