### PR TITLE
fix(buck): improve Complete API with optional body and docs

### DIFF
--- a/ceres/src/api_service/mono_api_service.rs
+++ b/ceres/src/api_service/mono_api_service.rs
@@ -2603,10 +2603,14 @@ impl MonoApiService {
 
     /// Complete buck upload.
     ///
+    /// Commit message is read from session.commit_message which is set during Manifest phase.
+    /// The payload is intentionally unused (empty struct).
+    ///
     /// # Arguments
     /// * `username` - User completing the upload
     /// * `cl_link` - CL link
-    /// * `payload` - Complete payload containing an optional commit message
+    /// * `_payload` - Empty payload (unused). Commit message is read from session.commit_message
+    ///   which is set during Manifest phase.
     ///
     /// # Returns
     /// Returns `CompleteResponse` on success

--- a/jupiter/src/service/buck_service.rs
+++ b/jupiter/src/service/buck_service.rs
@@ -841,10 +841,14 @@ impl BuckService {
     /// Validates all files are uploaded, then persists commit artifacts (trees, commit,
     /// CL refs, and CL record) within a database transaction. Updates session status to COMPLETED.
     ///
+    /// Commit message is read from `session.commit_message` which is set during Manifest phase.
+    /// The payload is intentionally unused (empty struct).
+    ///
     /// # Arguments
     /// * `username` - User completing the upload
     /// * `cl_link` - CL link (8-character alphanumeric identifier)
-    /// * `payload` - Complete payload containing an optional commit message
+    /// * `_payload` - Empty payload (unused). Commit message is read from session.commit_message
+    ///   which is set during Manifest phase via `update_session_status_with_pool`.
     /// * `commit_artifacts` - Optional commit artifacts from MonoApiService (Git build in ceres)
     ///
     /// # Returns

--- a/mono/tests/buck_service_tests.rs
+++ b/mono/tests/buck_service_tests.rs
@@ -1220,6 +1220,25 @@ async fn test_complete_upload_success() {
         .unwrap()
         .unwrap();
     assert_eq!(session.status, session_status::COMPLETED);
+
+    // Regression test: Verify session.commit_message is preserved
+    assert_eq!(
+        session.commit_message,
+        Some("Test commit".to_string()),
+        "session.commit_message should be preserved from Manifest phase"
+    );
+
+    // Regression test: Verify CL title uses session.commit_message
+    let cl = storage
+        .cl_storage()
+        .get_cl(session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        cl.title, "Test commit",
+        "CL title should use commit_message from session"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
- Make Complete request body optional (Option<Json<CompletePayload>>)
- Update rustdoc to reflect commit_message from session
- Add regression tests for commit_message preservation

link #1926 