### PR TITLE
Feat/orion vm deploy

### DIFF
--- a/.github/workflows/orion-client-deploy.yml
+++ b/.github/workflows/orion-client-deploy.yml
@@ -53,9 +53,17 @@ jobs:
             target/release/scorpio
 
   deploy:
-    if: ${{ github.repository == 'web3infra-foundation/mega' }}
+    # NOTE: Upstream repo protection in the original workflow prevents forks from running this job.
+    # We keep the original condition for upstream, but allow forks to run on workflow_dispatch.
+    if: ${{ github.repository == 'web3infra-foundation/mega' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     needs: build
+
+    env:
+      PROJECT_ID: infra-20250121-20260121-0235
+      ZONE: asia-east1-a
+      VM_NAME: buck2-hub-orion-client-vm
+
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -63,23 +71,26 @@ jobs:
           name: orion-scorpio-bins
           path: ./artifacts
 
-      - name: Upload binaries via rsync
-        uses: burnett01/rsync-deployments@master
+      - name: Auth to GCP
+        uses: google-github-actions/auth@v2
         with:
-          switches: -avz --progress
-          path: artifacts/orion artifacts/scorpio
-          remote_path: /root/orion-runner/
-          remote_host: ${{ secrets.ORION_DEPLOY_HOST }}
-          remote_user: root
-          remote_key: ${{ secrets.ORION_DEPLOY_SSH_KEY }}
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
 
-      - name: Restart service
-        uses: appleboy/ssh-action@v1.0.3
-        with:
-          host: ${{ secrets.ORION_DEPLOY_HOST }}
-          username: root
-          key: ${{ secrets.ORION_DEPLOY_SSH_KEY }}
-          script: |
-            systemctl daemon-reload
-            systemctl restart orion-runner.service
-            systemctl status orion-runner.service --no-pager
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Upload binaries to GCE VM
+        run: |
+          gcloud compute scp \
+            ./artifacts/orion \
+            ./artifacts/scorpio \
+            "${VM_NAME}:/tmp/" \
+            --zone="${ZONE}" \
+            --project="${PROJECT_ID}"
+
+      - name: Install binaries and restart service
+        run: |
+          gcloud compute ssh "${VM_NAME}" \
+            --zone="${ZONE}" \
+            --project="${PROJECT_ID}" \
+            --command="sudo mv /tmp/orion /usr/local/bin/orion && sudo mv /tmp/scorpio /usr/local/bin/scorpio && sudo chmod +x /usr/local/bin/orion /usr/local/bin/scorpio && sudo systemctl restart orion-worker.service && sudo systemctl status orion-worker.service --no-pager"

--- a/.github/workflows/orion-client-deploy.yml
+++ b/.github/workflows/orion-client-deploy.yml
@@ -16,7 +16,6 @@ concurrency:
 
 jobs:
   build:
-    # 允许 upstream 正常触发，同时在 fork 中可以通过 workflow_dispatch 手动触发
     if: ${{ github.repository == 'web3infra-foundation/mega' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -56,7 +55,6 @@ jobs:
             target/release/scorpio
 
   deploy:
-    # upstream 继续限制只在主仓库触发；在 fork 中可以通过 workflow_dispatch 手动触发
     if: ${{ github.repository == 'web3infra-foundation/mega' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     needs: build
@@ -65,14 +63,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # 单台 VM 示例：使用仓库 Secrets ORION_DEPLOY_HOST_1 / ORION_DEPLOY_SSH_KEY_1
           - name: orion-vm-1
             host_secret: ORION_DEPLOY_HOST_1
             ssh_key_secret: ORION_DEPLOY_SSH_KEY_1
-          # 如需多台，再追加：
-          # - name: orion-vm-2
-          #   host_secret: ORION_DEPLOY_HOST_2
-          #   ssh_key_secret: ORION_DEPLOY_SSH_KEY_2
 
     env:
       ORION_DEPLOY_HOST: ${{ secrets[matrix.host_secret] }}

--- a/.github/workflows/orion-client-deploy.yml
+++ b/.github/workflows/orion-client-deploy.yml
@@ -1,4 +1,5 @@
 name: Orion client deploy
+
 on:
   push:
     branches:
@@ -7,6 +8,7 @@ on:
       - ".github/workflows/orion-client-deploy.yml"
       - "orion/**"
       - "scorpio/**"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,7 +16,8 @@ concurrency:
 
 jobs:
   build:
-    if: ${{ github.repository == 'web3infra-foundation/mega' }}
+    # 允许 upstream 正常触发，同时在 fork 中可以通过 workflow_dispatch 手动触发
+    if: ${{ github.repository == 'web3infra-foundation/mega' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -53,16 +56,28 @@ jobs:
             target/release/scorpio
 
   deploy:
-    # NOTE: Upstream repo protection in the original workflow prevents forks from running this job.
-    # We keep the original condition for upstream, but allow forks to run on workflow_dispatch.
+    # upstream 继续限制只在主仓库触发；在 fork 中可以通过 workflow_dispatch 手动触发
     if: ${{ github.repository == 'web3infra-foundation/mega' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     needs: build
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # 单台 VM 示例：使用仓库 Secrets ORION_DEPLOY_HOST_1 / ORION_DEPLOY_SSH_KEY_1
+          - name: orion-vm-1
+            host_secret: ORION_DEPLOY_HOST_1
+            ssh_key_secret: ORION_DEPLOY_SSH_KEY_1
+          # 如需多台，再追加：
+          # - name: orion-vm-2
+          #   host_secret: ORION_DEPLOY_HOST_2
+          #   ssh_key_secret: ORION_DEPLOY_SSH_KEY_2
+
     env:
-      PROJECT_ID: infra-20250121-20260121-0235
-      ZONE: asia-east1-a
-      VM_NAME: buck2-hub-orion-client-vm
+      ORION_DEPLOY_HOST: ${{ secrets[matrix.host_secret] }}
+      ORION_DEPLOY_SSH_KEY: ${{ secrets[matrix.ssh_key_secret] }}
+      ORION_DEPLOY_SSH_USER: wiedersehenm
 
     steps:
       - name: Download build artifacts
@@ -71,26 +86,21 @@ jobs:
           name: orion-scorpio-bins
           path: ./artifacts
 
-      - name: Auth to GCP
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Upload binaries to GCE VM
+      - name: Prepare SSH key
         run: |
-          gcloud compute scp \
+          mkdir -p ~/.ssh
+          printf '%s\n' "${ORION_DEPLOY_SSH_KEY}" > ~/.ssh/orion_deploy_key
+          chmod 600 ~/.ssh/orion_deploy_key
+
+      - name: Upload binaries to VM via SSH
+        run: |
+          scp -i ~/.ssh/orion_deploy_key -o StrictHostKeyChecking=no \
             ./artifacts/orion \
             ./artifacts/scorpio \
-            "${VM_NAME}:/tmp/" \
-            --zone="${ZONE}" \
-            --project="${PROJECT_ID}"
+            "${ORION_DEPLOY_SSH_USER}@${ORION_DEPLOY_HOST}:/tmp/"
 
       - name: Install binaries and restart service
         run: |
-          gcloud compute ssh "${VM_NAME}" \
-            --zone="${ZONE}" \
-            --project="${PROJECT_ID}" \
-            --command="sudo mv /tmp/orion /usr/local/bin/orion && sudo mv /tmp/scorpio /usr/local/bin/scorpio && sudo chmod +x /usr/local/bin/orion /usr/local/bin/scorpio && sudo systemctl restart orion-worker.service && sudo systemctl status orion-worker.service --no-pager"
+          ssh -i ~/.ssh/orion_deploy_key -o StrictHostKeyChecking=no \
+            "${ORION_DEPLOY_SSH_USER}@${ORION_DEPLOY_HOST}" \
+            "sudo mv /tmp/orion /usr/local/bin/orion && sudo mv /tmp/scorpio /usr/local/bin/scorpio && sudo chmod +x /usr/local/bin/orion /usr/local/bin/scorpio && sudo systemctl restart orion-worker.service && sudo systemctl status orion-worker.service --no-pager"

--- a/.github/workflows/orion-client-deploy.yml
+++ b/.github/workflows/orion-client-deploy.yml
@@ -62,7 +62,6 @@ jobs:
           retention-days: 7
 
   deploy:
-    # Upstream仓库只允许 main 分支部署到生产；fork 中仍可通过 workflow_dispatch 进行手动测试。
     if: >
       (github.repository == 'web3infra-foundation/mega' && github.ref == 'refs/heads/main')
       || (github.repository != 'web3infra-foundation/mega' && github.event_name == 'workflow_dispatch')

--- a/.github/workflows/orion-client-deploy.yml
+++ b/.github/workflows/orion-client-deploy.yml
@@ -1,5 +1,8 @@
 name: Orion client deploy
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -12,7 +15,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -42,9 +45,12 @@ jobs:
 
       - name: Verify build artifacts
         run: |
-          ls -lh target/release || true
-          file target/release/orion || true
-          file target/release/scorpio || true
+          set -e
+          ls -lh target/release
+          test -f target/release/orion
+          test -f target/release/scorpio
+          file target/release/orion
+          file target/release/scorpio
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -53,11 +59,16 @@ jobs:
           path: |
             target/release/orion
             target/release/scorpio
+          retention-days: 7
 
   deploy:
-    if: ${{ github.repository == 'web3infra-foundation/mega' || github.event_name == 'workflow_dispatch' }}
+    # Upstream仓库只允许 main 分支部署到生产；fork 中仍可通过 workflow_dispatch 进行手动测试。
+    if: >
+      (github.repository == 'web3infra-foundation/mega' && github.ref == 'refs/heads/main')
+      || (github.repository != 'web3infra-foundation/mega' && github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     needs: build
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false
@@ -68,9 +79,9 @@ jobs:
             ssh_key_secret: ORION_DEPLOY_SSH_KEY_1
 
     env:
-      ORION_DEPLOY_HOST: ${{ secrets[matrix.host_secret] }}
-      ORION_DEPLOY_SSH_KEY: ${{ secrets[matrix.ssh_key_secret] }}
-      ORION_DEPLOY_SSH_USER: wiedersehenm
+      ORION_DEPLOY_HOST: ${{ secrets.ORION_DEPLOY_HOST_1 }}
+      ORION_DEPLOY_SSH_KEY: ${{ secrets.ORION_DEPLOY_SSH_KEY_1 }}
+      ORION_DEPLOY_SSH_USER: ${{ secrets.ORION_DEPLOY_SSH_USER_1 }}
 
     steps:
       - name: Download build artifacts
@@ -79,21 +90,37 @@ jobs:
           name: orion-scorpio-bins
           path: ./artifacts
 
+      - name: Make artifacts executable
+        run: chmod +x ./artifacts/orion ./artifacts/scorpio
+
       - name: Prepare SSH key
         run: |
           mkdir -p ~/.ssh
           printf '%s\n' "${ORION_DEPLOY_SSH_KEY}" > ~/.ssh/orion_deploy_key
           chmod 600 ~/.ssh/orion_deploy_key
 
+      - name: Add host to known_hosts
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -H "${ORION_DEPLOY_HOST}" >> ~/.ssh/known_hosts
+
       - name: Upload binaries to VM via SSH
         run: |
-          scp -i ~/.ssh/orion_deploy_key -o StrictHostKeyChecking=no \
+          scp -i ~/.ssh/orion_deploy_key \
             ./artifacts/orion \
             ./artifacts/scorpio \
             "${ORION_DEPLOY_SSH_USER}@${ORION_DEPLOY_HOST}:/tmp/"
 
       - name: Install binaries and restart service
         run: |
-          ssh -i ~/.ssh/orion_deploy_key -o StrictHostKeyChecking=no \
+          ssh -i ~/.ssh/orion_deploy_key \
             "${ORION_DEPLOY_SSH_USER}@${ORION_DEPLOY_HOST}" \
-            "sudo mv /tmp/orion /usr/local/bin/orion && sudo mv /tmp/scorpio /usr/local/bin/scorpio && sudo chmod +x /usr/local/bin/orion /usr/local/bin/scorpio && sudo systemctl restart orion-worker.service && sudo systemctl status orion-worker.service --no-pager"
+            "sudo mv /tmp/orion /usr/local/bin/orion && \
+             sudo mv /tmp/scorpio /usr/local/bin/scorpio && \
+             sudo chmod +x /usr/local/bin/orion /usr/local/bin/scorpio && \
+             sudo systemctl restart orion-worker.service && \
+             sudo systemctl status orion-worker.service --no-pager"
+
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f ~/.ssh/orion_deploy_key


### PR DESCRIPTION
## Summary

- Add an Orion client GCE VM on GCP via Terraform (Debian 13 image).
- Move Orion client deployment to a CI-built + SSH-based workflow using ORION_DEPLOY_HOST / ORION_DEPLOY_SSH_KEY.
- Provision the VM with a startup script that installs runtime dependencies, Buck2, and a systemd service for the Orion worker.

## Details

- **Terraform (deployment/envs/gcp/prod)**
  - Add `google_compute_instance.orion_client_vm` using the `debian-cloud/debian-13` image, sized as `e2-standard-4` and attached to the existing `buck2hub-vpc3` / `buck2hub-subnet` network.
  - Extract the previous inline `metadata_startup_script` into `scripts/startup-orion-client.sh` to keep `main.tf` clean.
  - In `startup-orion-client.sh`:
    - Install required runtime packages (Rust toolchain, Buck2, fuse3, build-essential, etc.).
    - Create the `orion-worker-wrapper` script that starts a local Scorpio instance and then the Orion worker.
    - Write and enable a `systemd` unit `orion-worker.service` so the worker can be managed and restarted by the OS.
  - Remove the old `install_from_tgz.sh`-based flow so the VM no longer builds Orion/Scorpio from a tarball; it now expects pre-built binaries to be delivered by CI.

- **GitHub Actions (orion-client-deploy.yml)**
  - Add a `workflow_dispatch` trigger so forks can manually run the workflow and test Orion client deployment.
  - Keep the existing `build` job but rely on it to produce release binaries for `orion` and `scorpio` and upload them as artifacts.
  - Replace `gcloud compute scp/ssh` with a matrix‑driven SSH deployment:
    - Use `ORION_DEPLOY_HOST_*` and `ORION_DEPLOY_SSH_KEY_*` secrets from the matrix to connect to one or more Orion client VMs.
    - `scp` the CI-built `orion` and `scorpio` binaries into `/tmp/` on the VM, then move them into `/usr/local/bin/` and mark them executable.
    - Restart and check the `orion-worker.service` on the remote VM to complete the rollout.

## Testing

- Applied Terraform in `deployment/envs/gcp/prod` to create the Orion client VM and verified:
  - Startup script runs successfully on a fresh Debian 13 instance.
  - `orion-worker-wrapper` is installed at `/usr/local/bin/orion-worker-wrapper`.
  - `orion-worker.service` is created, enabled, and can be started via `systemctl`.
- Ran `Orion client deploy` workflow via `workflow_dispatch` against the new VM:
  - Confirmed CI builds `orion` and `scorpio`, uploads artifacts, and deploys them via SSH.
  - Verified on the VM that `orion-worker.service` is active and that `orion` / `scorpio` binaries in `/usr/local/bin/` match the CI build.

## Notes

- This PR assumes `ORION_DEPLOY_HOST_*` and `ORION_DEPLOY_SSH_KEY_*` secrets are configured in the target repository.
- Future teammates can reproduce the flow by:
  - Applying Terraform to create a fresh Orion client VM.
  - Updating the `ORION_DEPLOY_HOST_*` secret with the new VM IP.
  - Running the `Orion client deploy` workflow via `workflow_dispatch`.