### PR TITLE
 ci(orion): fix orion VM deployment

### DIFF
--- a/.github/workflows/orion-client-deploy.yml
+++ b/.github/workflows/orion-client-deploy.yml
@@ -64,7 +64,7 @@ jobs:
 
   # Deploy to legacy orion_vm (root user, backward compatibility)
   deploy-legacy:
-    if: ${{ github.repository == 'web3infra-foundation/mega' }}
+    if: false  # Temporarily disabled
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 10
@@ -167,7 +167,7 @@ jobs:
 
   # Deploy to new GCP VM (orion user, best practice)
   deploy-gcp:
-    if: ${{ github.repository == 'Ivanbeethoven/mega' }}
+    if: ${{ github.repository == 'web3infra-foundation/mega' }}
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 10

--- a/.github/workflows/orion-client-deploy.yml
+++ b/.github/workflows/orion-client-deploy.yml
@@ -58,9 +58,12 @@ jobs:
             orion/runner-config/.env.prod
             orion/runner-config/scorpio.toml
             orion/runner-config/run.sh
+            orion/runner-config/cleanup.sh
+            orion/systemd/orion-runner.service
           retention-days: 7
 
-  deploy:
+  # Deploy to legacy orion_vm (root user, backward compatibility)
+  deploy-legacy:
     if: ${{ github.repository == 'web3infra-foundation/mega' }}
     runs-on: ubuntu-latest
     needs: build
@@ -87,17 +90,26 @@ jobs:
           #                 artifacts/orion/runner-config/run.sh
           
           # Move files to artifacts root for deployment
-          mv artifacts/target/release/orion artifacts/
+          # IMPORTANT: Move config files first (while orion/ directory still exists)
           mv artifacts/orion/runner-config/.env.prod artifacts/.env
           mv artifacts/orion/runner-config/scorpio.toml artifacts/
           mv artifacts/orion/runner-config/run.sh artifacts/
+          mv artifacts/orion/runner-config/cleanup.sh artifacts/
           
-          # Clean up empty directories
-          rm -rf artifacts/target artifacts/orion
+          # Move systemd service file
+          mv artifacts/orion/systemd/orion-runner.service artifacts/
+          
+          # Clean up empty orion directory before moving binary
+          rm -rf artifacts/orion
+          
+          # Now move the binary (orion/ directory has been removed)
+          mv artifacts/target/release/orion artifacts/orion
+          rm -rf artifacts/target
           
           # Set executable permissions
           chmod +x artifacts/orion
           chmod +x artifacts/run.sh
+          chmod +x artifacts/cleanup.sh
           
           echo "==> Final artifact structure:"
           ls -la artifacts/
@@ -106,19 +118,6 @@ jobs:
       # The legacy orion_vm was provisioned with root-only SSH access.
       # For backward compatibility and to avoid breaking existing
       # production automation, deployment continues to use the root user.
-      #
-      # The new GCP VM correctly uses a non-root `orion` user.
-      # Future infrastructure revisions should migrate orion_vm
-      # to a least-privilege deployment user.
-      - name: Upload binaries and configs via rsync to orion_vm
-        uses: burnett01/rsync-deployments@8.0.4
-        with:
-          switches: -avz --progress
-          path: artifacts/
-          remote_path: /root/orion-runner/
-          remote_host: ${{ secrets.ORION_DEPLOY_HOST }}
-          remote_user: root
-          remote_key: ${{ secrets.ORION_DEPLOY_SSH_KEY }}
       - name: Stop service on orion_vm (before deployment)
         uses: appleboy/ssh-action@v1.0.3
         with:
@@ -128,6 +127,10 @@ jobs:
           script: |
             # Stop service to allow binary replacement
             systemctl stop orion-runner.service || echo "Service not running"
+            sleep 2
+            
+            # Force cleanup if service is stuck
+            pkill -9 orion || true
       
       - name: Upload binaries and configs via rsync to orion_vm
         uses: burnett01/rsync-deployments@8.0.4
@@ -153,11 +156,60 @@ jobs:
             # Set permissions
             chmod +x /root/orion-runner/orion
             chmod +x /root/orion-runner/run.sh
+            chmod +x /root/orion-runner/cleanup.sh
             
             # Start service
             systemctl daemon-reload
             systemctl start orion-runner.service
+            
+            echo "✓ Service start command completed"
             systemctl status orion-runner.service --no-pager
+
+  # Deploy to new GCP VM (orion user, best practice)
+  deploy-gcp:
+    if: ${{ github.repository == 'Ivanbeethoven/mega' }}
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 10
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: orion-bins
+          path: ./artifacts
+
+      - name: Prepare deployment files
+        run: |
+          set -e
+          echo "==> Listing downloaded artifacts structure:"
+          find artifacts -type f -ls
+          
+          echo "==> Preparing deployment files..."
+          # Move files to artifacts root for deployment
+          # IMPORTANT: Move config files first (while orion/ directory still exists)
+          mv artifacts/orion/runner-config/.env.prod artifacts/.env
+          mv artifacts/orion/runner-config/scorpio.toml artifacts/
+          mv artifacts/orion/runner-config/run.sh artifacts/
+          mv artifacts/orion/runner-config/cleanup.sh artifacts/
+          
+          # Move systemd service file
+          mv artifacts/orion/systemd/orion-runner.service artifacts/
+          
+          # Clean up empty directories before moving binary
+          rm -rf artifacts/orion
+          
+          # Now move the binary (orion/ directory has been removed)
+          mv artifacts/target/release/orion artifacts/orion
+          rm -rf artifacts/target
+          
+          # Set executable permissions
+          chmod +x artifacts/orion
+          chmod +x artifacts/run.sh
+          chmod +x artifacts/cleanup.sh
+          
+          echo "==> Final artifact structure:"
+          ls -la artifacts/
 
       - name: Stop service on gcp_vm (before deployment)
         uses: appleboy/ssh-action@v1.0.3
@@ -168,6 +220,14 @@ jobs:
           script: |
             # Stop service to allow binary replacement
             sudo systemctl stop orion-runner.service || echo "Service not running"
+            sleep 2
+            
+            # Force cleanup if service is stuck
+            sudo pkill -9 orion || true
+            
+            # Force unmount FUSE if still mounted
+            fusermount -uz /workspace/mount 2>/dev/null || true
+            sudo umount -lf /workspace/mount 2>/dev/null || true
       
       - name: Upload binaries and configs via rsync to gcp_vm
         uses: burnett01/rsync-deployments@8.0.4
@@ -194,8 +254,16 @@ jobs:
             # Set permissions
             chmod +x /home/orion/orion-runner/orion
             chmod +x /home/orion/orion-runner/run.sh
+            chmod +x /home/orion/orion-runner/cleanup.sh
             
-            # Start service
+            # Update systemd service file if changed
+            if [ -f /home/orion/orion-runner/orion-runner.service ]; then
+                sudo cp /home/orion/orion-runner/orion-runner.service /etc/systemd/system/
+                echo "✓ Updated systemd service file"
+            fi
+            
+            # Reload systemd and start service
             sudo systemctl daemon-reload
             sudo systemctl start orion-runner.service
-            sudo systemctl status orion-runner.service --no-pager
+            
+            echo "✓ Service start command completed"

--- a/orion/runner-config/cleanup.sh
+++ b/orion/runner-config/cleanup.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# ==============================================================================
+#  Orion Runner 清理脚本（systemd ExecStartPre）
+#
+#  说明：
+#  - 在服务启动前执行，清理旧进程和 FUSE 挂载
+#  - 即使失败也不会阻止服务启动
+# ==============================================================================
+
+set +e  # 允许命令失败，不中断脚本
+
+SCORPIO_TOML="${SCORPIO_CONFIG:-/home/orion/orion-runner/scorpio.toml}"
+
+# 从 scorpio.toml 读取路径
+read_scorpio_path() {
+    local key="$1"
+    local file="$2"
+    if [ -f "$file" ]; then
+        awk -F'"' -v k="$key" '$1 ~ "^"k"[[:space:]]*=" {print $2; exit}' "$file"
+    fi
+}
+
+echo "==> [清理] 停止旧进程..."
+if command -v buck2 &>/dev/null; then
+    echo "  - 正在执行 'buck2 killall'..."
+    buck2 killall 2>&1 || echo "  - buck2 killall 完成"
+fi
+
+# Only kill the orion binary, not this cleanup script
+# Use full path match to avoid killing ourselves
+if pgrep -f "/orion-runner/orion" >/dev/null 2>&1; then
+    echo "  - 正在终止旧的 orion 进程..."
+    pkill -9 -f "/orion-runner/orion" 2>&1 || echo "  - 进程清理完成"
+else
+    echo "  - 没有找到运行中的 orion 进程"
+fi
+
+echo "==> [清理] 卸载 FUSE 挂载点..."
+MOUNT_DIR="$(read_scorpio_path "workspace" "${SCORPIO_TOML}")"
+MOUNT_DIR="${MOUNT_DIR:-/workspace/mount}"
+
+echo "  - 正在卸载 ${MOUNT_DIR}..."
+fusermount -uz "${MOUNT_DIR}" 2>/dev/null || true
+umount -lf "${MOUNT_DIR}" 2>/dev/null || true
+
+# 清理并重建挂载目录
+if ! mountpoint -q "${MOUNT_DIR}" 2>/dev/null; then
+    rm -rf "${MOUNT_DIR}" 2>/dev/null || true
+    mkdir -p "${MOUNT_DIR}" 2>/dev/null || true
+    echo "  - 挂载点已清理"
+else
+    echo "  - ${MOUNT_DIR} 仍是挂载点，跳过删除"
+fi
+
+echo "==> [清理] 完成"
+exit 0  # 总是返回成功

--- a/orion/runner-config/run.sh
+++ b/orion/runner-config/run.sh
@@ -4,23 +4,12 @@
 #  Orion Runner 启动脚本（systemd ExecStart）
 #
 #  说明：
-#  - Scorpio 已集成进 Orion（通过 scorpiofs），此脚本不再启动 scorpio 进程
-#  - 每次启动前会清理旧进程和 FUSE 挂载，确保环境干净
-#  - 配置：SCORPIO_CONFIG 环境变量 → 当前目录 scorpio.toml
+#  - Scorpio 已集成进 Orion（通过 scorpiofs）
+#  - 清理工作由 cleanup.sh（ExecStartPre）完成
+#  - 此脚本只负责启动 orion 进程
 # ==============================================================================
 
 set -euo pipefail
-
-SCORPIO_TOML="scorpio.toml"
-
-# 从 scorpio.toml 读取路径
-read_scorpio_path() {
-    local key="$1"
-    local file="$2"
-    if [ -f "$file" ]; then
-        awk -F'"' -v k="$key" '$1 ~ "^"k"[[:space:]]*=" {print $2; exit}' "$file"
-    fi
-}
 
 # 加载环境变量
 if [ -f "./.env" ]; then
@@ -48,44 +37,14 @@ if [ ! -f "${SCORPIO_CONFIG}" ]; then
 fi
 
 # ==============================================================================
-#  启动前清理：停止旧进程、卸载 FUSE
-# ==============================================================================
-
-echo "==> [1/3] 停止旧进程..."
-if command -v buck2 &>/dev/null; then
-    echo "  - 正在执行 'buck2 killall'..."
-    buck2 killall || echo "  - 'buck2 killall' 执行完毕或没有进程可杀。"
-fi
-pkill -f "./orion" || echo "  - 没有找到 orion 进程。"
-
-echo "==> [2/3] 卸载 FUSE 挂载点..."
-MOUNT_DIR="$(read_scorpio_path "workspace" "${SCORPIO_TOML}")"
-MOUNT_DIR="${MOUNT_DIR:-/workspace/mount}"
-
-echo "  - 正在卸载 ${MOUNT_DIR}..."
-fusermount -u "${MOUNT_DIR}" \
-    || umount -l "${MOUNT_DIR}" \
-    || umount -f "${MOUNT_DIR}" \
-    || echo "  - 卸载可能未完全成功，将继续执行清理。"
-
-# 若已卸载，则删除并重建目录，解决 "Transport endpoint" 问题
-echo "  - 正在清理并重建挂载目录..."
-if mountpoint -q "${MOUNT_DIR}"; then
-    echo "  - ${MOUNT_DIR} 仍是挂载点，跳过删除目录。"
-else
-    rm -rf "${MOUNT_DIR}" || true
-    mkdir -p "${MOUNT_DIR}"
-fi
-echo "  - 挂载点已清理。"
-
-# ==============================================================================
 #  启动 Orion
 # ==============================================================================
 
-echo "==> [3/3] 启动 orion..."
+echo "==> 启动 orion..."
 LOG_DIR="${PWD}/log"
 ORION_LOG="${LOG_DIR}/orion.log"
 mkdir -p "${LOG_DIR}"
 
+echo "  - 配置: ${SCORPIO_CONFIG}"
 echo "  - 日志: ${ORION_LOG}"
 exec ./orion >>"${ORION_LOG}" 2>&1

--- a/orion/systemd/orion-runner.service
+++ b/orion/systemd/orion-runner.service
@@ -14,17 +14,23 @@ WorkingDirectory=/home/orion/orion-runner
 EnvironmentFile=-/etc/orion/orion-runner.env
 
 # Scorpiofs config path (stable default expected by orion/src/antares.rs)
-Environment=SCORPIO_CONFIG=/etc/scorpio/scorpio.toml
-ExecStartPre=/usr/bin/test -f /etc/scorpio/scorpio.toml
+Environment=SCORPIO_CONFIG=/home/orion/orion-runner/scorpio.toml
 
-ExecStart=/home/orion/orion-runner/orion
+# Cleanup before start: kill old processes and unmount FUSE
+ExecStartPre=/home/orion/orion-runner/cleanup.sh
+
+# Start orion (run.sh loads .env and starts the binary)
+ExecStart=/home/orion/orion-runner/run.sh
 Restart=always
 RestartSec=2
 
-# Basic hardening (keep minimal to avoid breaking buck2/scorpiofs IO)
-NoNewPrivileges=true
+# Grant capabilities for FUSE mounting
+AmbientCapabilities=CAP_SYS_ADMIN
+CapabilityBoundingSet=CAP_SYS_ADMIN CAP_DAC_OVERRIDE
+
+# Basic hardening (relaxed for FUSE operations)
+NoNewPrivileges=false
 PrivateTmp=true
-ProtectSystem=full
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Disable deploy-legacy job to focus testing on the new GCP VM 
deployment infrastructure. The legacy orion_vm deployment has 
been temporarily disabled by setting `if: false` condition.

Changes:
- Set deploy-legacy job condition to `if: false`
- Keep deploy-gcp job active for GCP VM deployment
- Both jobs remain in workflow for easy re-enabling

Context:
The deploy-gcp job has been refactored with improved error handling,
proper cleanup separation (cleanup.sh + run.sh), FUSE capabilities,
and SSH timeout fixes. This change allows isolated testing of the
new infrastructure without interference from legacy deployment.

Note on CI behavior:
- GitHub Actions will show deploy-legacy as "Skipped"
- If deploy-gcp completes successfully, the workflow passes
- The service may successfully deploy even if CI reports timeout/failure
  (check service status directly: `systemctl status orion-runner`)