### PR TITLE
fix: allow closing draft CLs and fix draft list ordering

### DIFF
--- a/jupiter/src/storage/cl_storage.rs
+++ b/jupiter/src/storage/cl_storage.rs
@@ -107,9 +107,7 @@ impl ClStorage {
         sort_map.insert("updated_at", mega_cl::Column::UpdatedAt);
 
         let sort_field = params.sort_by.as_deref();
-        let has_valid_sort = sort_field
-            .and_then(|field| sort_map.get(field))
-            .is_some();
+        let has_valid_sort = sort_field.and_then(|field| sort_map.get(field)).is_some();
 
         let mut sorted_query = apply_sort(base_query, sort_field, params.asc, &sort_map);
 

--- a/jupiter/src/storage/cl_storage.rs
+++ b/jupiter/src/storage/cl_storage.rs
@@ -106,10 +106,14 @@ impl ClStorage {
         sort_map.insert("created_at", mega_cl::Column::CreatedAt);
         sort_map.insert("updated_at", mega_cl::Column::UpdatedAt);
 
-        let mut sorted_query =
-            apply_sort(base_query, params.sort_by.as_deref(), params.asc, &sort_map);
+        let sort_field = params.sort_by.as_deref();
+        let has_valid_sort = sort_field
+            .and_then(|field| sort_map.get(field))
+            .is_some();
 
-        if params.sort_by.is_none() {
+        let mut sorted_query = apply_sort(base_query, sort_field, params.asc, &sort_map);
+
+        if !has_valid_sort {
             sorted_query = sorted_query.order_by_desc(mega_cl::Column::Id);
         }
 

--- a/jupiter/src/storage/cl_storage.rs
+++ b/jupiter/src/storage/cl_storage.rs
@@ -100,14 +100,18 @@ impl ClStorage {
                 q.filter(mega_cl::Column::Username.eq(author))
             })
             .filter(cond)
-            .distinct()
-            .order_by_asc(mega_cl::Column::Id);
+            .distinct();
 
         let mut sort_map = HashMap::new();
         sort_map.insert("created_at", mega_cl::Column::CreatedAt);
         sort_map.insert("updated_at", mega_cl::Column::UpdatedAt);
 
-        let sorted_query = apply_sort(base_query, params.sort_by.as_deref(), params.asc, &sort_map);
+        let mut sorted_query =
+            apply_sort(base_query, params.sort_by.as_deref(), params.asc, &sort_map);
+
+        if params.sort_by.is_none() {
+            sorted_query = sorted_query.order_by_desc(mega_cl::Column::Id);
+        }
 
         let paginator = sorted_query.paginate(self.get_connection(), page.per_page);
         let total = paginator.num_items().await?;

--- a/mono/src/api/router/cl_router.rs
+++ b/mono/src/api/router/cl_router.rs
@@ -108,7 +108,7 @@ async fn close_cl(
     let res = state.cl_stg().get_cl(&link).await?;
     let model = res.ok_or(MegaError::Other("Not Found".to_string()))?;
 
-    if model.status == MergeStatusEnum::Open {
+    if matches!(model.status, MergeStatusEnum::Open | MergeStatusEnum::Draft) {
         let link = model.link.clone();
         state.cl_stg().close_cl(model).await?;
         state


### PR DESCRIPTION
## Summary
- Allow draft change lists (CLs) to be closed via the existing close API.
- Fix ordering of CL list so newly created CLs (including drafts) appear first as expected.

## Changes
- Updated `close_cl` handler to close CLs when their status is either `Open` or `Draft`, and still record a `Closed` conversation event.
- Removed the unconditional `ORDER BY id ASC` from `ClStorage::get_cl_list` to avoid overriding user-specified sort options.
- Applied dynamic sorting based on `sort_by` (`created_at` or `updated_at`) and `asc`, and defaulted to `ORDER BY id DESC` when no sort field is provided so newest CLs show up on the first page.

## Notes
- Reviewer and merge flows remain blocked for draft CLs; this change only affects closing and list ordering.