### PR TITLE
fix large file upload trigger cl

### DIFF
--- a/ceres/src/api_service/mono_api_service.rs
+++ b/ceres/src/api_service/mono_api_service.rs
@@ -116,6 +116,8 @@ pub struct MonoApiService {
     pub git_object_cache: Arc<GitObjectCache>,
 }
 
+const LARGE_CL_RENAME_DETECTION_THRESHOLD: usize = 1000;
+
 impl From<&MonoRepo> for MonoApiService {
     fn from(mono_repo: &MonoRepo) -> Self {
         MonoApiService {
@@ -3027,6 +3029,18 @@ impl MonoApiService {
                 _ => None,
             })
             .collect();
+
+        if base_diff.len() > LARGE_CL_RENAME_DETECTION_THRESHOLD
+            || candidate_hashes.len() > LARGE_CL_RENAME_DETECTION_THRESHOLD
+        {
+            tracing::info!(
+                diff_files = base_diff.len(),
+                candidate_hashes = candidate_hashes.len(),
+                threshold = LARGE_CL_RENAME_DETECTION_THRESHOLD,
+                "Skipping rename detection for large CL diff and returning path-level results."
+            );
+            return Ok(base_diff);
+        }
 
         for hash in candidate_hashes {
             match self.get_raw_blob_by_hash(&hash.to_string()).await {

--- a/orion/src/antares.rs
+++ b/orion/src/antares.rs
@@ -401,9 +401,18 @@ Hint: set SCORPIO_CONFIG=/path/to/scorpio.toml or create /etc/scorpio/scorpio.to
         }
     }
 
+    fn cl_files_timeout() -> Duration {
+        std::env::var("ORION_CL_FILES_TIMEOUT_SECS")
+            .ok()
+            .and_then(|raw| raw.parse::<u64>().ok())
+            .filter(|secs| *secs > 0)
+            .map(Duration::from_secs)
+            .unwrap_or_else(|| Duration::from_secs(120))
+    }
+
     fn http_client() -> Result<Client, DynError> {
         Client::builder()
-            .timeout(Duration::from_secs(30))
+            .timeout(cl_files_timeout())
             .build()
             .map_err(|err| {
                 Box::new(io_other(format!(
@@ -810,3 +819,4 @@ mod imp {
 }
 
 pub use imp::*;
+

--- a/orion/src/antares.rs
+++ b/orion/src/antares.rs
@@ -819,4 +819,3 @@ mod imp {
 }
 
 pub use imp::*;
-


### PR DESCRIPTION
修复bug：Ceres的files-list api会遍历所有对象，导致大文件提交cl时，worker侧会因为获取files-list超时导致任务失败