### PR TITLE
fix(orion): move get_manager() before scorpio config reads; remove ea…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,8 @@ orion-server/docker-compose.override.yml
 
 # Claude Code configuration and cache
 .claude
+
+tools/**
+
+.libra
+.libraignore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4986,7 +4986,7 @@ dependencies = [
 
 [[package]]
 name = "orion"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "api-model",

--- a/orion/Cargo.toml
+++ b/orion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orion"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [[bin]]

--- a/orion/src/antares.rs
+++ b/orion/src/antares.rs
@@ -458,7 +458,16 @@ Hint: set SCORPIO_CONFIG=/path/to/scorpio.toml or create /etc/scorpio/scorpio.to
     pub(crate) async fn warmup_dicfuse() -> Result<(), DynError> {
         tracing::info!("Initializing Antares Dicfuse during Orion startup");
 
-        // DEBUG: Log Dicfuse configuration
+        // NOTE: do not read scorpio config accessors before `get_manager()`.
+        // `get_manager()` is what calls `scorpiofs::util::config::init_config(...)`.
+        // Reading accessors first would trigger scorpiofs' lazy DEFAULT_CONFIG
+        // fallback, and any values logged here would be the built-in defaults
+        // (e.g. base_url=http://localhost:8000) rather than the values from
+        // the scorpio.toml that init_config is about to load.
+        let manager = get_manager().await?;
+        let manager_for_test_mount = Arc::clone(manager);
+        let dicfuse = manager.dicfuse();
+
         let workspace_path = scorpiofs::util::config::workspace();
         let base_url = scorpiofs::util::config::base_url();
         let store_path = scorpiofs::util::config::store_path();
@@ -466,12 +475,8 @@ Hint: set SCORPIO_CONFIG=/path/to/scorpio.toml or create /etc/scorpio/scorpio.to
             workspace = %workspace_path,
             base_url = %base_url,
             store_path = %store_path,
-            "DEBUG: Dicfuse prewarm configuration"
+            "Dicfuse prewarm configuration"
         );
-
-        let manager = get_manager().await?;
-        let manager_for_test_mount = Arc::clone(manager);
-        let dicfuse = manager.dicfuse();
 
         dicfuse.start_import();
 

--- a/orion/src/buck_controller.rs
+++ b/orion/src/buck_controller.rs
@@ -588,24 +588,6 @@ async fn get_build_targets(
         "DEBUG: Buck2 get_build_targets paths"
     );
 
-    // DEBUG: Check mount_path contents
-    if mount_path.exists() {
-        match std::fs::read_dir(&mount_path) {
-            Ok(entries) => {
-                let dir_contents: Vec<_> = entries
-                    .filter_map(|e| e.ok())
-                    .map(|e| e.file_name().to_string_lossy().to_string())
-                    .collect();
-                tracing::debug!(mount_path = %mount_path.display(), contents = ?dir_contents, "DEBUG: Mount path directory contents");
-            }
-            Err(e) => {
-                tracing::warn!(mount_path = %mount_path.display(), error = %e, "DEBUG: Failed to read mount path");
-            }
-        }
-    } else {
-        tracing::warn!(mount_path = %mount_path.display(), "DEBUG: Mount path does not exist!");
-    }
-
     tracing::debug!("Analyzing changes {mega_changes:?}");
 
     preheat_shallow(&mount_path, preheat_shallow_depth())?;


### PR DESCRIPTION
…ger mount enumeration

- antares/warmup_dicfuse: call get_manager() before reading scorpio config accessors to avoid logging default values instead of loaded config
- buck_controller: remove synchronous read_dir enumeration from get_build_targets debug block (expensive I/O on large repos)
- .gitignore: add tools/ and .libra entries