### PR TITLE
Update Orion ScorpioFS dependency for stale inode recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4412,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "libfuse-fs"
 version = "0.1.13"
-source = "git+https://github.com/web3infra-foundation/scorpiofs.git?rev=beecf7dd2906806c686d0c17d80348dddc4a55e9#beecf7dd2906806c686d0c17d80348dddc4a55e9"
+source = "git+https://github.com/web3infra-foundation/scorpiofs.git?rev=e228b34116f9bc460637894cf5f71ed829e1dc03#e228b34116f9bc460637894cf5f71ed829e1dc03"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -7662,7 +7662,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scorpiofs"
 version = "0.2.2"
-source = "git+https://github.com/web3infra-foundation/scorpiofs.git?rev=beecf7dd2906806c686d0c17d80348dddc4a55e9#beecf7dd2906806c686d0c17d80348dddc4a55e9"
+source = "git+https://github.com/web3infra-foundation/scorpiofs.git?rev=e228b34116f9bc460637894cf5f71ed829e1dc03#e228b34116f9bc460637894cf5f71ed829e1dc03"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4412,8 +4412,7 @@ dependencies = [
 [[package]]
 name = "libfuse-fs"
 version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61be2a0235d6a5ba30064c172f12d5465da0f013281a0e6675604d0781496e9"
+source = "git+https://github.com/web3infra-foundation/scorpiofs.git?rev=beecf7dd2906806c686d0c17d80348dddc4a55e9#beecf7dd2906806c686d0c17d80348dddc4a55e9"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -7663,7 +7662,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scorpiofs"
 version = "0.2.2"
-source = "git+https://github.com/web3infra-foundation/scorpiofs.git?rev=900309f0abc397ccf8b9565ae0da2e3ef1e65618#900309f0abc397ccf8b9565ae0da2e3ef1e65618"
+source = "git+https://github.com/web3infra-foundation/scorpiofs.git?rev=beecf7dd2906806c686d0c17d80348dddc4a55e9#beecf7dd2906806c686d0c17d80348dddc4a55e9"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/orion/Cargo.toml
+++ b/orion/Cargo.toml
@@ -39,4 +39,4 @@ serial_test = { workspace = true }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-scorpiofs = { git = "https://github.com/web3infra-foundation/scorpiofs.git", rev = "900309f0abc397ccf8b9565ae0da2e3ef1e65618" }
+scorpiofs = { git = "https://github.com/web3infra-foundation/scorpiofs.git", rev = "beecf7dd2906806c686d0c17d80348dddc4a55e9" }

--- a/orion/Cargo.toml
+++ b/orion/Cargo.toml
@@ -39,4 +39,4 @@ serial_test = { workspace = true }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-scorpiofs = { git = "https://github.com/web3infra-foundation/scorpiofs.git", rev = "beecf7dd2906806c686d0c17d80348dddc4a55e9" }
+scorpiofs = { git = "https://github.com/web3infra-foundation/scorpiofs.git", rev = "e228b34116f9bc460637894cf5f71ed829e1dc03" }


### PR DESCRIPTION
## Summary
- update Orion's `scorpiofs` git dependency to `e228b34116f9bc460637894cf5f71ed829e1dc03`
- pull in the vendored `libfuse-fs` unionfs stale-inode rematerialization and path recovery fixes
- keep the PR scoped to the dependency pin update on top of upstream `main`

## Verification
- `BINDGEN_EXTRA_CLANG_ARGS='-I/usr/lib/gcc/x86_64-linux-gnu/13/include' cargo test -p orion antares_unmount_grace_duration`
- local Orion/Antares/Buck2 E2E with `buck2 ed81560d9a14bc866adadd6f9a73e8a015236e5c9c2e82323b9dce3e678654e1`: task `019ee3c7-53fe-7aa0-93cb-01722be80eb0`, build `019ee3c7-5400-7c80-b2ae-6f594c180220`, `/v2/build-state` = `Completed`, DB `exit_code=0`, build log `BUILD SUCCEEDED`
- fresh E2E log scan: `BUILD FAILED=0`, `ENOENT=0`, `EBADF=0`, `os error 9=0`, `panic=0`; one non-fatal rfuse3 interrupted-request `os error 2` warning occurred after build success during cleanup
