### PR TITLE
chore(orion): use published scorpiofs crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4439,8 +4439,9 @@ dependencies = [
 
 [[package]]
 name = "libfuse-fs"
-version = "0.1.13"
-source = "git+https://github.com/rk8s-dev/rk8s.git?branch=codex%2Fstabilize-libfuse-buck2-races#66ce9a6c95e27bb7b06bfec0a6f12bdd74a3565f"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818b22fed635a8c39500037246a136595ac01fdc00c029dce59b42f6bd800f39"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -7049,8 +7050,9 @@ dependencies = [
 
 [[package]]
 name = "rfuse3"
-version = "0.0.8"
-source = "git+https://github.com/rk8s-dev/rk8s.git?branch=codex%2Fstabilize-libfuse-buck2-races#66ce9a6c95e27bb7b06bfec0a6f12bdd74a3565f"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6edadac8a81eefae9a2c3ad55cb5af4b8421cb27e44bc8a3334916973582bd2"
 dependencies = [
  "aligned_box",
  "async-notify",
@@ -7696,8 +7698,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scorpiofs"
-version = "0.2.2"
-source = "git+https://github.com/web3infra-foundation/scorpiofs.git?branch=codex%2Fantares-fuse-local-libfuse#286147cd9295f68b1fad56994fc59adaca6ff50d"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7be35390c9691cc1023b9b1673dd84595e2db60f908f9bf6de42b97d84a1daa"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/orion/Cargo.toml
+++ b/orion/Cargo.toml
@@ -37,4 +37,4 @@ serial_test = { workspace = true }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-scorpiofs = { git = "https://github.com/web3infra-foundation/scorpiofs.git", branch = "codex/antares-fuse-local-libfuse" }
+scorpiofs = "0.2.3"


### PR DESCRIPTION
## Summary
- switch orion's Linux scorpiofs dependency from the temporary git branch to scorpiofs 0.2.3
- update Cargo.lock to resolve scorpiofs/rfuse3/libfuse-fs from crates.io

## Verification
- cargo fmt --check
- cargo metadata --format-version 1 --locked
- git diff --check

Note: local clippy for this workspace is blocked on this Windows host by missing libclang.dll for zstd-sys/bindgen; CI should validate in GitHub.