### PR TITLE
release(orion): update to scorpiofs 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "asyncfuse"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73944bd789372ebf1f10a25ee59296bbb437b31dbe234dcd959e98a1f3238fac"
+dependencies = [
+ "aligned_box",
+ "async-notify",
+ "async-trait",
+ "bincode 1.3.3",
+ "bytes",
+ "dashmap 6.2.1",
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "nix 0.29.0",
+ "serde",
+ "slab",
+ "tokio",
+ "tracing",
+ "trait-make",
+ "which",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,6 +1607,15 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+dependencies = [
+ "clap",
 ]
 
 [[package]]
@@ -4759,11 +4792,12 @@ dependencies = [
 
 [[package]]
 name = "libfuse-fs"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818b22fed635a8c39500037246a136595ac01fdc00c029dce59b42f6bd800f39"
+checksum = "be34f425e314ea461827fae3b4f8a23c48575af9fca974df51a74ee2c463c0d1"
 dependencies = [
  "async-trait",
+ "asyncfuse",
  "bitflags 2.13.1",
  "bytes",
  "clap",
@@ -4777,7 +4811,6 @@ dependencies = [
  "nix 0.29.0",
  "radix_trie 0.2.1",
  "reqwest 0.12.28",
- "rfuse3",
  "serde",
  "serde_json",
  "tokio",
@@ -7414,30 +7447,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfuse3"
-version = "0.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6edadac8a81eefae9a2c3ad55cb5af4b8421cb27e44bc8a3334916973582bd2"
-dependencies = [
- "aligned_box",
- "async-notify",
- "async-trait",
- "bincode 1.3.3",
- "bytes",
- "dashmap 6.2.1",
- "futures-channel",
- "futures-util",
- "libc",
- "nix 0.29.0",
- "serde",
- "slab",
- "tokio",
- "tracing",
- "trait-make",
- "which",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8063,16 +8072,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scorpiofs"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7be35390c9691cc1023b9b1673dd84595e2db60f908f9bf6de42b97d84a1daa"
+checksum = "f97b336153167ba1101236eb8c55c29736e5651d17f02e551c5b4fb4f4aab3ff"
 dependencies = [
  "async-recursion",
  "async-trait",
+ "asyncfuse",
  "axum",
  "bincode 2.0.1",
  "bytes",
  "clap",
+ "clap_complete",
  "crossbeam",
  "dashmap 6.2.1",
  "env_logger",
@@ -8085,7 +8096,6 @@ dependencies = [
  "once_cell",
  "radix_trie 0.3.0",
  "reqwest 0.13.4",
- "rfuse3",
  "ring",
  "serde",
  "serde_json",
@@ -8095,6 +8105,7 @@ dependencies = [
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
  "whoami 1.6.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4792,9 +4792,9 @@ dependencies = [
 
 [[package]]
 name = "libfuse-fs"
-version = "0.1.15"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be34f425e314ea461827fae3b4f8a23c48575af9fca974df51a74ee2c463c0d1"
+checksum = "cf5f1ba3c5498a7b893d4398dfd6de0f21d87d16f1385258950d62d5a7806af8"
 dependencies = [
  "async-trait",
  "asyncfuse",
@@ -8072,9 +8072,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scorpiofs"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97b336153167ba1101236eb8c55c29736e5651d17f02e551c5b4fb4f4aab3ff"
+checksum = "cdb7184ebd1e1329f143d95f1388e6b61f9fa057eba671467035a559a73c9d1c"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/orion/Cargo.toml
+++ b/orion/Cargo.toml
@@ -37,4 +37,4 @@ serial_test = { workspace = true }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-scorpiofs = "0.2.3"
+scorpiofs = "0.2.4"

--- a/orion/Cargo.toml
+++ b/orion/Cargo.toml
@@ -37,4 +37,4 @@ serial_test = { workspace = true }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-scorpiofs = "0.2.4"
+scorpiofs = "0.3.0"

--- a/orion/src/main.rs
+++ b/orion/src/main.rs
@@ -23,7 +23,7 @@ async fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| EnvFilter::new("info,rfuse3::raw::session=error")),
+                .unwrap_or_else(|_| EnvFilter::new("info,asyncfuse::raw::session=error")),
         )
         .with_target(true)
         .with_writer(|| LineWriter::new(stderr()))


### PR DESCRIPTION
## Summary

- update Orion to `scorpiofs 0.3.0`
- resolve `libfuse-fs 0.2.0` through the published dependency chain
- keep the async-fuse migration on SemVer-compatible major/minor versions

## Validation

- `cargo +1.97.0 fmt --all -- --check`
- published crates confirmed through the official crates.io index