### PR TITLE
chore(orion): update scorpiofs to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7756,7 +7756,7 @@ dependencies = [
  "dashmap 6.2.1",
  "env_logger",
  "futures",
- "git-internal 0.4.1",
+ "git-internal 0.8.5",
  "hex",
  "libc",
  "libfuse-fs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7740,9 +7740,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scorpiofs"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb7184ebd1e1329f143d95f1388e6b61f9fa057eba671467035a559a73c9d1c"
+checksum = "5805127aaaff2b35f99b008a5b9570257ea69ee2f181c2154ea9b30d73e2d416"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/orion/Cargo.toml
+++ b/orion/Cargo.toml
@@ -37,4 +37,4 @@ serial_test = { workspace = true }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-scorpiofs = "0.3.0"
+scorpiofs = "0.4.0"


### PR DESCRIPTION
﻿## Summary
- update Orion's Linux-only `scorpiofs` dependency to `0.4.0`
- refresh `Cargo.lock`

## Why
Orion integrates the ScorpioFS crate directly and passes the CL subpath into its Antares mount flow.

## Validation
- `scorpiofs 0.4.0` was published and Cargo-verified
- Antares-backed `buck2 build //project/distribution:distribution` succeeded

## Note
The configured TUNA Cargo mirror had not yet synced `0.4.0` when the lockfile was updated. The lockfile checksum is the SHA-256 of the crates.io release package.
